### PR TITLE
perf: replace circular SlidingWindow with linear decode buffer

### DIFF
--- a/src/transcoder/boundary.rs
+++ b/src/transcoder/boundary.rs
@@ -1,32 +1,87 @@
-use super::window::SlidingWindow;
 use crate::deflate::tokens::LZ77Token;
+
+/// Maximum LZ77 back-reference distance (32KB).
+const MAX_DISTANCE: usize = 32768;
 
 /// Resolves LZ77 back-references that cross BGZF block boundaries.
 ///
-/// The key insight: we only need to resolve references where the
-/// referenced data would be in a *previous* BGZF block. References
-/// within the same block can remain as Copy tokens.
+/// Uses a linear decode buffer instead of a circular sliding window.
+/// The buffer holds `[prev_tail: up to 32KB] [current_block: growing]`,
+/// enabling:
+/// - Simple array indexing for Copy lookups (no circular wrapping)
+/// - Single contiguous CRC hash per block (enables SIMD in crc32fast)
+/// - Bulk memcpy for non-RLE Copies
 pub struct BoundaryResolver {
-    /// 32KB sliding window of resolved (uncompressed) bytes
-    window: SlidingWindow,
+    /// Linear buffer: previous block tail + current block's decoded bytes.
+    /// Layout: `[0..tail_len] = previous block's last 32KB`
+    ///         `[tail_len..tail_len+current_len] = current block's bytes`
+    decode_buf: Vec<u8>,
+    /// Length of the previous-block tail portion (0..=32768)
+    tail_len: usize,
+    /// Current block's decoded byte count (bytes written past tail_len)
+    current_len: usize,
     /// Current position in the uncompressed stream
     position: u64,
     /// Statistics
     refs_resolved: u64,
     refs_preserved: u64,
-    /// Reusable buffer for resolving Copy references (avoids allocation per Copy)
-    copy_buffer: Vec<u8>,
 }
 
 impl BoundaryResolver {
     pub fn new() -> Self {
+        // Pre-allocate for typical BGZF block: 32KB tail + ~72KB block
         Self {
-            window: SlidingWindow::new(),
+            decode_buf: Vec::with_capacity(MAX_DISTANCE + 72 * 1024),
+            tail_len: 0,
+            current_len: 0,
             position: 0,
             refs_resolved: 0,
             refs_preserved: 0,
-            copy_buffer: Vec::with_capacity(258), // Max DEFLATE match length
         }
+    }
+
+    /// Append a byte to the current block region of the decode buffer.
+    #[inline(always)]
+    fn push_byte(&mut self, byte: u8) {
+        self.decode_buf.push(byte);
+        self.current_len += 1;
+    }
+
+    /// Copy `length` bytes from `distance` bytes back in the decode buffer.
+    /// Handles both non-RLE (distance >= length) and RLE (distance < length) cases.
+    #[inline]
+    fn copy_from_back(&mut self, distance: u16, length: u16) {
+        debug_assert!(distance > 0);
+        let dist = distance as usize;
+        let len = length as usize;
+        let src_start = self.decode_buf.len() - dist;
+
+        if dist >= len {
+            // Non-RLE: source doesn't overlap destination
+            self.decode_buf.extend_from_within(src_start..src_start + len);
+        } else {
+            // RLE: source overlaps destination, byte-by-byte with pattern repeat
+            self.decode_buf.reserve(len);
+            for i in 0..len {
+                let byte = self.decode_buf[src_start + (i % dist)];
+                self.decode_buf.push(byte);
+            }
+        }
+        self.current_len += len;
+    }
+
+    /// Prepare for the next block: shift the last 32KB of decoded data
+    /// to become the tail for the next block's lookups.
+    fn rotate_tail(&mut self) {
+        let total = self.decode_buf.len();
+        let keep = total.min(MAX_DISTANCE);
+        if keep < total {
+            // Shift the last `keep` bytes to the front
+            self.decode_buf.copy_within(total - keep..total, 0);
+            self.decode_buf.truncate(keep);
+        }
+        self.tail_len = keep;
+        self.current_len = 0;
     }
 
     /// Process tokens for a BGZF block, resolving cross-boundary LZ77 references.
@@ -41,39 +96,36 @@ impl BoundaryResolver {
         tokens: &[LZ77Token],
     ) -> (Vec<LZ77Token>, u32, u32) {
         let mut output = Vec::with_capacity(tokens.len());
-        let mut hasher = crc32fast::Hasher::new();
-        let mut uncompressed_size: u32 = 0;
 
         for token in tokens {
             match token {
                 LZ77Token::Literal(byte) => {
-                    self.window.push_byte(*byte);
+                    self.push_byte(*byte);
                     self.position += 1;
                     output.push(LZ77Token::Literal(*byte));
-                    hasher.update(&[*byte]);
-                    uncompressed_size += 1;
                 }
 
                 LZ77Token::Copy { length, distance } => {
                     let ref_start = self.position.saturating_sub(*distance as u64);
 
-                    self.copy_buffer.clear();
-                    self.window.copy_to_vec(*distance, *length, &mut self.copy_buffer);
-
                     if ref_start < block_start {
-                        for &byte in &self.copy_buffer {
+                        // Cross-boundary: resolve to literals
+                        let dist = *distance as usize;
+                        let len = *length as usize;
+                        let src_start = self.decode_buf.len() - dist;
+                        for i in 0..len {
+                            let byte = self.decode_buf[src_start + (i % dist)];
+                            self.push_byte(byte);
                             output.push(LZ77Token::Literal(byte));
                         }
-                        self.window.push_bytes(&self.copy_buffer);
                         self.refs_resolved += 1;
                     } else {
-                        self.window.push_bytes(&self.copy_buffer);
+                        // Within-block: preserve Copy, append decoded bytes
+                        self.copy_from_back(*distance, *length);
                         output.push(LZ77Token::Copy { length: *length, distance: *distance });
                         self.refs_preserved += 1;
                     }
 
-                    hasher.update(&self.copy_buffer);
-                    uncompressed_size += *length as u32;
                     self.position += *length as u64;
                 }
 
@@ -81,7 +133,18 @@ impl BoundaryResolver {
             }
         }
 
-        (output, hasher.finalize(), uncompressed_size)
+        let (crc, uncompressed_size) = self.finish_block();
+        (output, crc, uncompressed_size)
+    }
+
+    /// Finalize the current block: compute CRC over decoded bytes and rotate tail.
+    /// Returns (CRC32, uncompressed_size).
+    fn finish_block(&mut self) -> (u32, u32) {
+        let block_bytes = &self.decode_buf[self.tail_len..self.tail_len + self.current_len];
+        let crc = crc32fast::hash(block_bytes);
+        let uncompressed_size = self.current_len as u32;
+        self.rotate_tail();
+        (crc, uncompressed_size)
     }
 
     /// Get the current position in uncompressed stream
@@ -96,11 +159,12 @@ impl BoundaryResolver {
 
     /// Reset the resolver
     pub fn reset(&mut self) {
-        self.window.clear();
+        self.decode_buf.clear();
+        self.tail_len = 0;
+        self.current_len = 0;
         self.position = 0;
         self.refs_resolved = 0;
         self.refs_preserved = 0;
-        self.copy_buffer.clear();
     }
 }
 


### PR DESCRIPTION
## Summary

Replace the 32KB circular `SlidingWindow` with a linear decode buffer
`[prev_tail: 32KB | current_block: ~65KB]`:
- Copy lookups are simple array indexing (no circular wrapping)
- CRC computed in one `crc32fast::hash` call per block (~65KB, SIMD-friendly)
  instead of thousands of small `hasher.update` calls
- Non-RLE copies use `copy_within` (bulk memcpy)

**Stack**: #14 → #15 → #16

## Benchmarks (5.7 GB FASTQ gzip, Apple M-series, level 1)

| Threads | Before | After | Improvement |
|---------|--------|-------|-------------|
| 1 | 188s (32.8 MB/s) | 176s (35.0 MB/s) | +7% |
| 4 | 117s (52.5 MB/s) | 86s (71.8 MB/s) | **+37%** |

The 4-thread improvement is dramatic — the single-call CRC hash engages SIMD,
and linear buffer access has better cache behavior than the circular window.

## Test plan

- [x] 94 unit tests pass
- [x] 44 integration tests pass
- [x] Output verified via `pigz -dc | md5` against original

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal transcoder processing with more efficient buffer handling and block finalization logic.

---

**Note:** This release includes internal optimizations with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->