### PR TITLE
perf: compute CRC in resolver, eliminate tokens_to_bytes

### DIFF
--- a/src/transcoder/boundary.rs
+++ b/src/transcoder/boundary.rs
@@ -1,36 +1,6 @@
 use super::window::SlidingWindow;
 use crate::deflate::tokens::LZ77Token;
 
-/// Replay resolved tokens to get uncompressed bytes.
-/// Used by parallel workers to compute CRC.
-///
-/// IMPORTANT: Tokens must be pre-resolved (no cross-boundary references).
-pub fn tokens_to_bytes(tokens: &[LZ77Token]) -> Vec<u8> {
-    // Estimate capacity based on typical compression ratio
-    let mut output = Vec::with_capacity(tokens.len() * 2);
-
-    for token in tokens {
-        match token {
-            LZ77Token::Literal(byte) => {
-                output.push(*byte);
-            }
-            LZ77Token::Copy { length, distance } => {
-                let len = *length as usize;
-                let dist = *distance as usize;
-                let start = output.len() - dist;
-
-                // Handle both non-overlapping and RLE (overlapping) cases
-                for i in 0..len {
-                    output.push(output[start + (i % dist)]);
-                }
-            }
-            LZ77Token::EndOfBlock => {}
-        }
-    }
-
-    output
-}
-
 /// Resolves LZ77 back-references that cross BGZF block boundaries.
 ///
 /// The key insight: we only need to resolve references where the
@@ -59,15 +29,12 @@ impl BoundaryResolver {
         }
     }
 
-    /// Process tokens for a BGZF block (single-threaded mode).
+    /// Process tokens for a BGZF block, resolving cross-boundary LZ77 references.
     ///
     /// `block_start`: position where this BGZF block starts
     /// `tokens`: LZ77 tokens to process
     ///
     /// Returns: (tokens with cross-boundary references resolved, CRC32, uncompressed size)
-    ///
-    /// This version computes CRC inline, which is efficient when the main thread
-    /// is doing all the work anyway.
     pub fn resolve_block(
         &mut self,
         block_start: u64,
@@ -80,7 +47,6 @@ impl BoundaryResolver {
         for token in tokens {
             match token {
                 LZ77Token::Literal(byte) => {
-                    // Literals pass through unchanged
                     self.window.push_byte(*byte);
                     self.position += 1;
                     output.push(LZ77Token::Literal(*byte));
@@ -95,14 +61,12 @@ impl BoundaryResolver {
                     self.window.copy_to_vec(*distance, *length, &mut self.copy_buffer);
 
                     if ref_start < block_start {
-                        // Cross-boundary: resolve to literals, then batch-update window.
                         for &byte in &self.copy_buffer {
                             output.push(LZ77Token::Literal(byte));
                         }
                         self.window.push_bytes(&self.copy_buffer);
                         self.refs_resolved += 1;
                     } else {
-                        // Within-block: preserve Copy, batch-update window
                         self.window.push_bytes(&self.copy_buffer);
                         output.push(LZ77Token::Copy { length: *length, distance: *distance });
                         self.refs_preserved += 1;
@@ -113,67 +77,11 @@ impl BoundaryResolver {
                     self.position += *length as u64;
                 }
 
-                LZ77Token::EndOfBlock => {
-                    // Don't include EndOfBlock in output - we'll add our own
-                }
-            }
-        }
-
-        (output, hasher.finalize(), uncompressed_size)
-    }
-
-    /// Process tokens for a BGZF block (multi-threaded mode).
-    ///
-    /// `block_start`: position where this BGZF block starts
-    /// `tokens`: LZ77 tokens to process
-    ///
-    /// Returns: (tokens with cross-boundary references resolved, uncompressed size)
-    ///
-    /// This version does NOT compute CRC - workers will do that in parallel.
-    pub fn resolve_block_for_parallel(
-        &mut self,
-        block_start: u64,
-        tokens: &[LZ77Token],
-    ) -> (Vec<LZ77Token>, u32) {
-        let mut output = Vec::with_capacity(tokens.len());
-        let mut uncompressed_size: u32 = 0;
-
-        for token in tokens {
-            match token {
-                LZ77Token::Literal(byte) => {
-                    self.window.push_byte(*byte);
-                    self.position += 1;
-                    output.push(LZ77Token::Literal(*byte));
-                    uncompressed_size += 1;
-                }
-
-                LZ77Token::Copy { length, distance } => {
-                    let ref_start = self.position.saturating_sub(*distance as u64);
-
-                    self.copy_buffer.clear();
-                    self.window.copy_to_vec(*distance, *length, &mut self.copy_buffer);
-
-                    if ref_start < block_start {
-                        for &byte in &self.copy_buffer {
-                            output.push(LZ77Token::Literal(byte));
-                        }
-                        self.window.push_bytes(&self.copy_buffer);
-                        self.refs_resolved += 1;
-                    } else {
-                        self.window.push_bytes(&self.copy_buffer);
-                        output.push(LZ77Token::Copy { length: *length, distance: *distance });
-                        self.refs_preserved += 1;
-                    }
-
-                    uncompressed_size += *length as u32;
-                    self.position += *length as u64;
-                }
-
                 LZ77Token::EndOfBlock => {}
             }
         }
 
-        (output, uncompressed_size)
+        (output, hasher.finalize(), uncompressed_size)
     }
 
     /// Get the current position in uncompressed stream

--- a/src/transcoder/parallel.rs
+++ b/src/transcoder/parallel.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Write};
 
 use crossbeam::channel::{bounded, Receiver, Sender};
 
-use super::boundary::{tokens_to_bytes, BoundaryResolver};
+use super::boundary::BoundaryResolver;
 use super::splitter::{BlockSplitter, DefaultSplitter, FastqSplitter};
 use crate::bgzf::{GziEntry, BGZF_EOF};
 use crate::deflate::{DeflateParser, LZ77Token};
@@ -27,6 +27,8 @@ struct EncodingJob {
     tokens: Vec<LZ77Token>,
     /// Uncompressed size (pre-computed during boundary resolution)
     uncompressed_size: u32,
+    /// CRC32 of uncompressed data (pre-computed during boundary resolution)
+    crc: u32,
 }
 
 /// Result of encoding a single BGZF block
@@ -197,14 +199,14 @@ impl ParallelTranscoder {
                     };
 
                     if should_emit {
-                        // Resolve boundaries only - workers will compute CRC in parallel
-                        let (resolved, uncompressed_size) = resolver
-                            .resolve_block_for_parallel(block_start_position, &pending_tokens);
+                        let (resolved, crc, uncompressed_size) =
+                            resolver.resolve_block(block_start_position, &pending_tokens);
 
                         let job = EncodingJob {
                             block_id: next_block_id,
                             tokens: resolved,
                             uncompressed_size,
+                            crc,
                         };
                         next_block_id += 1;
 
@@ -271,10 +273,11 @@ impl ParallelTranscoder {
 
         // Flush remaining tokens
         if !pending_tokens.is_empty() {
-            let (resolved, uncompressed_size) =
-                resolver.resolve_block_for_parallel(block_start_position, &pending_tokens);
+            let (resolved, crc, uncompressed_size) =
+                resolver.resolve_block(block_start_position, &pending_tokens);
 
-            let job = EncodingJob { block_id: next_block_id, tokens: resolved, uncompressed_size };
+            let job =
+                EncodingJob { block_id: next_block_id, tokens: resolved, uncompressed_size, crc };
             next_block_id += 1;
 
             let _ = job_tx.send(job);
@@ -440,9 +443,7 @@ fn worker_thread(
 
 /// Encode a single BGZF block
 fn encode_block(encoder: &mut HuffmanEncoder, job: EncodingJob) -> Result<EncodedBlock> {
-    // Compute CRC from tokens (parallelized - each worker does this)
-    let uncompressed_bytes = tokens_to_bytes(&job.tokens);
-    let crc = crc32fast::hash(&uncompressed_bytes);
+    let crc = job.crc;
     let isize = job.uncompressed_size;
 
     // Encode to DEFLATE

--- a/src/transcoder/parallel_decode.rs
+++ b/src/transcoder/parallel_decode.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use crossbeam::channel::{bounded, Receiver, Sender};
 
 use super::block_scanner::scan_for_block;
-use super::boundary::{tokens_to_bytes, BoundaryResolver};
+use super::boundary::BoundaryResolver;
 use super::single::{parse_gzip_header_size, SingleThreadedTranscoder};
 use super::splitter::{BlockSplitter, DefaultSplitter, FastqSplitter};
 use crate::bgzf::{GziEntry, BGZF_EOF};
@@ -156,13 +156,14 @@ impl ParallelDecodeTranscoder {
                 };
 
                 if should_emit {
-                    let (resolved, uncompressed_size) =
-                        resolver.resolve_block_for_parallel(block_start_position, &pending_tokens);
+                    let (resolved, crc, uncompressed_size) =
+                        resolver.resolve_block(block_start_position, &pending_tokens);
 
                     let job = EncodingJob {
                         block_id: next_block_id,
                         tokens: resolved,
                         uncompressed_size,
+                        crc,
                     };
                     next_block_id += 1;
 
@@ -196,9 +197,10 @@ impl ParallelDecodeTranscoder {
         // a blocking send here can deadlock if both channels are full and workers
         // are blocked on result_tx.send while the main thread blocks on job_tx.send)
         if !pending_tokens.is_empty() {
-            let (resolved, uncompressed_size) =
-                resolver.resolve_block_for_parallel(block_start_position, &pending_tokens);
-            let job = EncodingJob { block_id: next_block_id, tokens: resolved, uncompressed_size };
+            let (resolved, crc, uncompressed_size) =
+                resolver.resolve_block(block_start_position, &pending_tokens);
+            let job =
+                EncodingJob { block_id: next_block_id, tokens: resolved, uncompressed_size, crc };
             next_block_id += 1;
             send_job_and_drain(
                 &job_tx,
@@ -595,6 +597,7 @@ struct EncodingJob {
     block_id: u64,
     tokens: Vec<LZ77Token>,
     uncompressed_size: u32,
+    crc: u32,
 }
 
 /// Result from a worker: an encoded BGZF block ready to write.
@@ -604,7 +607,7 @@ struct EncodedBlock {
     uncompressed_size: u32,
 }
 
-/// Worker thread: receives resolved token blocks, computes CRC, encodes BGZF.
+/// Worker thread: receives resolved token blocks, encodes BGZF.
 fn encoding_worker(
     job_rx: Receiver<EncodingJob>,
     result_tx: Sender<Result<EncodedBlock>>,
@@ -613,8 +616,7 @@ fn encoding_worker(
     let mut encoder = HuffmanEncoder::new(use_fixed_huffman);
 
     while let Ok(job) = job_rx.recv() {
-        let uncompressed_bytes = tokens_to_bytes(&job.tokens);
-        let crc = crc32fast::hash(&uncompressed_bytes);
+        let crc = job.crc;
         let isize = job.uncompressed_size;
 
         let result = match encoder.encode(&job.tokens, true) {


### PR DESCRIPTION
## Summary

- Move CRC32 computation into `BoundaryResolver::resolve_block`, which already touches every byte via the sliding window
- Pass pre-computed CRC through `EncodingJob` to encoding workers
- Workers no longer call `tokens_to_bytes` + `crc32fast::hash`, eliminating ~43GB of throwaway allocations on a 5.7GB input (64KB per block × 680K blocks)
- Consolidate `resolve_block` and `resolve_block_for_parallel` into a single method
- Remove dead `tokens_to_bytes` function

**Stack**: this PR → #15 → #16 → #17 → #19

## Benchmarks (5.7 GB FASTQ gzip, Apple M-series, level 1)

| Threads | Before | After | Improvement |
|---------|--------|-------|-------------|
| 1 | 220s (28.0 MB/s) | 188s (32.8 MB/s) | +17% |
| 4 | 143s (42.9 MB/s) | 117s (52.5 MB/s) | +22% |

## Test plan

- [x] 94 unit tests pass
- [x] 44 integration tests pass
- [x] `cargo fmt` and `cargo clippy` clean
- [x] Output verified via `pigz -dc | md5` against original

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized parallel transcoding performance by consolidating CRC computation to eliminate redundant calculations across encoding workers.
  * Simplified internal boundary resolution workflow for improved processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->