### PR TITLE
feat: add ParallelGzipReader with parallel multi-member decompression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ updates.md
 
 # PGO profile data
 /profiles/
+fgumi-bench/
+docs/superpowers/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,10 +83,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bumpalo"
@@ -102,9 +114,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -145,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -155,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -167,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -179,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
@@ -302,6 +314,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,12 +343,31 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -329,6 +382,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +407,24 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -372,10 +458,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libdeflate-sys"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
+dependencies = [
+ "libdeflate-sys",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -478,6 +600,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +626,12 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
@@ -525,8 +663,11 @@ dependencies = [
  "crossbeam",
  "flate2",
  "libc",
+ "libdeflater",
+ "memchr",
  "memmap2",
  "num_cpus",
+ "tempfile",
  "thiserror",
 ]
 
@@ -560,6 +701,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +733,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -653,6 +813,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +881,24 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -747,6 +944,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -803,6 +1034,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,18 @@ path = "src/bin/rebgzf.rs"
 # CRC32 for BGZF footer
 crc32fast = "1.3"
 
-# DEFLATE decompression for --verify mode
+# Fast DEFLATE decompression (verify mode, parallel decode)
+libdeflater = "1.22"
+
+# DEFLATE streaming fallback (retained for from_reader path)
 flate2 = "1.1"
 
 # Parallel processing
 crossbeam = "0.8"
 num_cpus = "1.16"
+
+# Fast byte scanning
+memchr = "2"
 
 # Error handling
 thiserror = "2.0"
@@ -45,9 +51,14 @@ flate2 = "1.1"
 # Use local bgzf for testing (clone from https://github.com/fulcrumgenomics/bgzf)
 # bgzf = { path = "../bgzf" }
 criterion = "0.8"
+tempfile = "3"
 
 [[bench]]
 name = "transcode"
+harness = false
+
+[[bench]]
+name = "reader"
 harness = false
 
 [profile.release]

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -1,0 +1,54 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use rebgzf::reader::ParallelGzipReader;
+use std::io::Read;
+
+fn gzip_compress(data: &[u8]) -> Vec<u8> {
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::Write;
+    let mut e = GzEncoder::new(Vec::new(), Compression::default());
+    e.write_all(data).unwrap();
+    e.finish().unwrap()
+}
+
+fn generate_dna_data(size: usize) -> Vec<u8> {
+    let bases = b"ACGTACGTNNNNACGTACGT";
+    (0..size).map(|i| bases[i % bases.len()]).collect()
+}
+
+fn bench_parallel_reader(c: &mut Criterion) {
+    let original = generate_dna_data(10 * 1024 * 1024); // 10 MB
+    let compressed = gzip_compress(&original);
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut group = c.benchmark_group("parallel_reader");
+    group.throughput(criterion::Throughput::Bytes(original.len() as u64));
+
+    for threads in [1, 2, 4, 8] {
+        group.bench_with_input(BenchmarkId::new("parallel", threads), &threads, |b, &threads| {
+            b.iter(|| {
+                let mut reader = ParallelGzipReader::from_file(tmp.path(), threads).unwrap();
+                let mut output = Vec::new();
+                reader.read_to_end(&mut output).unwrap();
+                assert_eq!(output.len(), original.len());
+            });
+        });
+    }
+
+    group.bench_function("flate2_baseline", |b| {
+        b.iter(|| {
+            let file = std::fs::File::open(tmp.path()).unwrap();
+            let mut reader = flate2::read::GzDecoder::new(std::io::BufReader::new(file));
+            let mut output = Vec::new();
+            reader.read_to_end(&mut output).unwrap();
+            assert_eq!(output.len(), original.len());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_parallel_reader);
+criterion_main!(benches);

--- a/src/bgzf/detector.rs
+++ b/src/bgzf/detector.rs
@@ -4,7 +4,6 @@
 //! (all blocks) for BGZF files.
 
 use crate::error::{Error, Result};
-use flate2::read::DeflateDecoder;
 use std::io::{Read, Seek, SeekFrom};
 
 /// Result of BGZF validation
@@ -300,18 +299,22 @@ pub fn verify_bgzf<R: Read>(reader: &mut R) -> Result<BgzfVerification> {
         let stored_crc = u32::from_le_bytes([footer[0], footer[1], footer[2], footer[3]]);
         let stored_isize = u32::from_le_bytes([footer[4], footer[5], footer[6], footer[7]]);
 
-        // Decompress data
-        let mut decompressed = Vec::new();
-        let mut decoder = DeflateDecoder::new(&compressed_data[..]);
-        if let Err(e) = decoder.read_to_end(&mut decompressed) {
-            result.is_valid_bgzf = false;
-            if result.first_error.is_none() {
-                result.first_error_block = Some(result.block_count);
-                result.first_error = Some(format!("Decompression failed: {}", e));
+        // Decompress data using libdeflate
+        let mut decompressor = libdeflater::Decompressor::new();
+        let mut decompressed = vec![0u8; stored_isize as usize];
+        match decompressor.deflate_decompress(&compressed_data, &mut decompressed) {
+            Ok(actual_size) => {
+                decompressed.truncate(actual_size);
             }
-            // Continue checking other blocks for stats
-            result.block_count += 1;
-            continue;
+            Err(e) => {
+                result.is_valid_bgzf = false;
+                if result.first_error.is_none() {
+                    result.first_error_block = Some(result.block_count);
+                    result.first_error = Some(format!("Decompression failed: {:?}", e));
+                }
+                result.block_count += 1;
+                continue;
+            }
         }
 
         // Verify ISIZE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod deflate;
 pub mod error;
 pub mod gzip;
 pub mod huffman;
+pub mod reader;
 pub mod transcoder;
 
 pub use bgzf::{
@@ -12,6 +13,7 @@ pub use bgzf::{
 };
 pub use deflate::tokens::LZ77Token;
 pub use error::{Error, Result};
+pub use reader::ParallelGzipReader;
 pub use transcoder::{
     parallel::ParallelTranscoder, parallel_decode::ParallelDecodeTranscoder,
     single::SingleThreadedTranscoder,

--- a/src/reader/chunk.rs
+++ b/src/reader/chunk.rs
@@ -1,0 +1,268 @@
+//! Decoded DEFLATE chunk that may contain unresolved marker values.
+//!
+//! During parallel speculative decoding, chunks are decoded without knowing the
+//! preceding 32KB window.  Back-references into the unknown window are stored as
+//! [`MarkerValue`] entries.  Once the window becomes available, markers are
+//! resolved in bulk via [`ChunkData::resolve_markers`].
+
+use super::marker::{apply_window, contains_markers, MarkerValue};
+
+/// Maximum DEFLATE sliding window size in bytes (32KB).
+const WINDOW_SIZE: usize = 32_768;
+
+/// A decoded DEFLATE chunk whose output may contain unresolved marker values.
+///
+/// Resolved byte buffers and marker buffers are stored separately.  After
+/// [`resolve_markers`](Self::resolve_markers) is called with the correct window,
+/// all marker buffers are converted to resolved byte buffers and the chunk
+/// becomes fully resolved.
+#[derive(Debug)]
+pub struct ChunkData {
+    /// Compressed offset in bits where this chunk starts.
+    pub encoded_offset: usize,
+    /// Compressed size in bits.
+    pub encoded_size: usize,
+    /// Fully resolved byte buffers.
+    resolved: Vec<Vec<u8>>,
+    /// Marker buffers awaiting window resolution.
+    markers: Vec<Vec<MarkerValue>>,
+    /// The 32KB window at the end of this chunk, used to resolve the next chunk.
+    pub final_window: Option<Vec<u8>>,
+    /// CRC32 of the decompressed data.
+    pub crc32: Option<u32>,
+}
+
+impl ChunkData {
+    /// Create a new chunk starting at the given compressed bit offset.
+    pub fn new(encoded_offset: usize) -> Self {
+        Self {
+            encoded_offset,
+            encoded_size: 0,
+            resolved: Vec::new(),
+            markers: Vec::new(),
+            final_window: None,
+            crc32: None,
+        }
+    }
+
+    /// Append a fully resolved byte buffer to this chunk.
+    pub fn append_resolved(&mut self, data: Vec<u8>) {
+        if !data.is_empty() {
+            self.resolved.push(data);
+        }
+    }
+
+    /// Append a marker buffer awaiting window resolution.
+    pub fn append_markers(&mut self, data: Vec<MarkerValue>) {
+        if !data.is_empty() {
+            self.markers.push(data);
+        }
+    }
+
+    /// Returns `true` if all data in this chunk is resolved (no markers remain).
+    pub fn is_resolved(&self) -> bool {
+        self.markers.is_empty()
+    }
+
+    /// Total decompressed size in bytes (resolved bytes + marker count).
+    pub fn decompressed_size(&self) -> usize {
+        let resolved_bytes: usize = self.resolved.iter().map(|v| v.len()).sum();
+        let marker_bytes: usize = self.markers.iter().map(|v| v.len()).sum();
+        resolved_bytes + marker_bytes
+    }
+
+    /// Resolve all marker buffers using the provided window.
+    ///
+    /// Each marker buffer is resolved via [`apply_window`] and converted into a
+    /// resolved byte buffer.  After this call, [`is_resolved`](Self::is_resolved)
+    /// returns `true`.
+    pub fn resolve_markers(&mut self, window: &[u8]) {
+        for marker_buf in self.markers.drain(..) {
+            let mut output = vec![0u8; marker_buf.len()];
+            apply_window(&marker_buf, window, &mut output);
+            self.resolved.push(output);
+        }
+    }
+
+    /// Move the resolved data out of this chunk, leaving it empty.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the chunk still contains unresolved markers.
+    pub fn take_output(&mut self) -> Vec<Vec<u8>> {
+        assert!(self.is_resolved(), "cannot take output: chunk has unresolved markers");
+        std::mem::take(&mut self.resolved)
+    }
+
+    /// Borrow the resolved byte buffers.
+    pub fn resolved_data(&self) -> &[Vec<u8>] {
+        &self.resolved
+    }
+
+    /// Recompute the final window from the resolved data.
+    ///
+    /// This must be called after [`resolve_markers`](Self::resolve_markers) to ensure
+    /// `final_window` contains correct bytes rather than placeholder zeros that were
+    /// emitted for unresolved markers during speculative decoding.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the chunk still contains unresolved markers.
+    pub fn recompute_final_window(&mut self) {
+        assert!(self.is_resolved(), "cannot recompute final window: chunk has unresolved markers");
+
+        let total_bytes: usize = self.resolved.iter().map(|v| v.len()).sum();
+        if total_bytes == 0 {
+            self.final_window = Some(Vec::new());
+            return;
+        }
+
+        // Always produce a full WINDOW_SIZE window, zero-padded at the start
+        // if the chunk produced fewer bytes. Marker offsets are 0-based into a
+        // 32KB window, so the window must always be exactly WINDOW_SIZE bytes.
+        let mut result = vec![0u8; WINDOW_SIZE];
+
+        if total_bytes >= WINDOW_SIZE {
+            // Take last WINDOW_SIZE bytes from the resolved buffers.
+            let mut skip = total_bytes - WINDOW_SIZE;
+            let mut pos = 0;
+            for buf in &self.resolved {
+                if skip >= buf.len() {
+                    skip -= buf.len();
+                    continue;
+                }
+                let src = &buf[skip..];
+                result[pos..pos + src.len()].copy_from_slice(src);
+                pos += src.len();
+                skip = 0;
+            }
+        } else {
+            // Fewer than WINDOW_SIZE bytes: zero-pad at the start, data at the end.
+            let pad = WINDOW_SIZE - total_bytes;
+            let mut pos = pad;
+            for buf in &self.resolved {
+                result[pos..pos + buf.len()].copy_from_slice(buf);
+                pos += buf.len();
+            }
+        }
+
+        self.final_window = Some(result);
+    }
+
+    /// Returns `true` if any marker buffer contains actual window references
+    /// (not just literals).
+    pub fn has_window_references(&self) -> bool {
+        self.markers.iter().any(|buf| contains_markers(buf))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_chunk() {
+        let chunk = ChunkData::new(1024);
+        assert_eq!(chunk.encoded_offset, 1024);
+        assert_eq!(chunk.encoded_size, 0);
+        assert!(chunk.is_resolved());
+        assert_eq!(chunk.decompressed_size(), 0);
+        assert!(chunk.final_window.is_none());
+        assert!(chunk.crc32.is_none());
+        assert!(!chunk.has_window_references());
+    }
+
+    #[test]
+    fn test_append_and_size() {
+        let mut chunk = ChunkData::new(0);
+
+        chunk.append_resolved(vec![1, 2, 3]);
+        assert_eq!(chunk.decompressed_size(), 3);
+        assert!(chunk.is_resolved());
+
+        chunk.append_markers(vec![MarkerValue::literal(10), MarkerValue::window_ref(0)]);
+        assert_eq!(chunk.decompressed_size(), 5);
+        assert!(!chunk.is_resolved());
+
+        // Empty appends should not change anything.
+        chunk.append_resolved(vec![]);
+        chunk.append_markers(vec![]);
+        assert_eq!(chunk.decompressed_size(), 5);
+    }
+
+    #[test]
+    fn test_resolve_markers() {
+        let mut chunk = ChunkData::new(0);
+
+        let window: Vec<u8> = vec![0xAA, 0xBB, 0xCC];
+
+        chunk.append_markers(vec![
+            MarkerValue::literal(0xFF),
+            MarkerValue::window_ref(1),
+            MarkerValue::window_ref(2),
+        ]);
+        assert!(!chunk.is_resolved());
+
+        chunk.resolve_markers(&window);
+        assert!(chunk.is_resolved());
+        assert_eq!(chunk.decompressed_size(), 3);
+        assert_eq!(chunk.resolved_data(), &[vec![0xFF, 0xBB, 0xCC]]);
+    }
+
+    #[test]
+    fn test_take_output() {
+        let mut chunk = ChunkData::new(0);
+        let window: Vec<u8> = vec![0x42];
+
+        chunk.append_resolved(vec![1, 2]);
+        chunk.append_markers(vec![MarkerValue::window_ref(0)]);
+
+        chunk.resolve_markers(&window);
+        let output = chunk.take_output();
+        assert_eq!(output, vec![vec![1, 2], vec![0x42]]);
+
+        // After take, chunk is empty.
+        assert_eq!(chunk.decompressed_size(), 0);
+        assert!(chunk.is_resolved());
+    }
+
+    #[test]
+    #[should_panic(expected = "unresolved markers")]
+    fn test_take_output_panics_with_unresolved() {
+        let mut chunk = ChunkData::new(0);
+        chunk.append_markers(vec![MarkerValue::window_ref(0)]);
+        let _ = chunk.take_output();
+    }
+
+    #[test]
+    fn test_empty_chunk() {
+        let mut chunk = ChunkData::new(0);
+        assert!(chunk.is_resolved());
+        assert_eq!(chunk.decompressed_size(), 0);
+        assert!(!chunk.has_window_references());
+
+        let output = chunk.take_output();
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_resolved_data_accessor() {
+        let mut chunk = ChunkData::new(0);
+        chunk.append_resolved(vec![10, 20, 30]);
+        chunk.append_resolved(vec![40, 50]);
+        assert_eq!(chunk.resolved_data(), &[vec![10, 20, 30], vec![40, 50]]);
+    }
+
+    #[test]
+    fn test_has_window_references() {
+        let mut chunk = ChunkData::new(0);
+
+        // All-literal markers: no window references.
+        chunk.append_markers(vec![MarkerValue::literal(1), MarkerValue::literal(2)]);
+        assert!(!chunk.has_window_references());
+
+        // Add markers with an actual window ref.
+        chunk.append_markers(vec![MarkerValue::window_ref(0)]);
+        assert!(chunk.has_window_references());
+    }
+}

--- a/src/reader/fetcher.rs
+++ b/src/reader/fetcher.rs
@@ -1,0 +1,783 @@
+//! Chunk fetcher that orchestrates parallel speculative decode + marker replacement.
+//!
+//! Splits compressed DEFLATE data into chunks, decodes them in parallel using
+//! [`speculative_decode`], and resolves markers sequentially once preceding
+//! windows become available.
+
+use super::chunk::ChunkData;
+use super::replacer::replace_markers;
+use super::speculative::{decode_with_libdeflate, speculative_decode};
+use crate::error::{Error, Result};
+use crate::gzip::GzipHeader;
+use crate::transcoder::block_scanner::{scan_for_block, BlockBoundary};
+
+/// Configuration for the parallel chunk fetcher.
+pub struct FetcherConfig {
+    /// Number of worker threads for parallel decode.
+    pub threads: usize,
+    /// Target bytes of compressed data per chunk (default 4 MiB).
+    pub chunk_size: usize,
+    /// Whether to verify CRC32 checksums after decompressing each member (default: true).
+    pub verify_crc: bool,
+}
+
+impl Default for FetcherConfig {
+    fn default() -> Self {
+        Self { threads: 4, chunk_size: 4 * 1024 * 1024, verify_crc: true }
+    }
+}
+
+/// Parallel chunk fetcher that decodes and resolves DEFLATE chunks.
+///
+/// All chunks are decoded in parallel using [`crossbeam::scope`] and resolved
+/// sequentially before being handed out via [`next_chunk`](Self::next_chunk).
+pub struct ChunkFetcher {
+    /// All chunks, fully resolved and in order.
+    resolved_chunks: Vec<ChunkData>,
+    /// Index of the next chunk to hand out.
+    next_index: usize,
+}
+
+impl ChunkFetcher {
+    /// Create a fetcher and run the parallel decode pipeline.
+    ///
+    /// This blocks until all chunks are decoded and resolved.
+    ///
+    /// # Arguments
+    /// * `data` - the full compressed file data (e.g. mmap'd)
+    /// * `header_size` - byte offset where DEFLATE data begins (after gzip header)
+    /// * `deflate_end` - byte offset where DEFLATE data ends (before gzip trailer)
+    /// * `config` - parallelism and chunking configuration
+    pub fn new(
+        data: &[u8],
+        header_size: usize,
+        deflate_end: usize,
+        config: FetcherConfig,
+    ) -> Result<Self> {
+        let num_threads = config.threads.max(1);
+
+        // Generate chunk boundaries (bit offsets).
+        let boundaries = generate_boundaries(data, header_size, deflate_end, config.chunk_size);
+
+        if boundaries.is_empty() {
+            return Ok(Self { resolved_chunks: vec![], next_index: 0 });
+        }
+
+        if boundaries.len() == 1 {
+            // Single chunk: use libdeflate fast path for the entire DEFLATE stream.
+            let deflate_data = &data[header_size..deflate_end];
+
+            // Read ISIZE from gzip trailer (last 4 bytes of trailer = expected decompressed size mod 2^32).
+            let isize_bytes = &data[deflate_end..deflate_end + 4.min(data.len() - deflate_end)];
+            let expected_size = if isize_bytes.len() >= 4 {
+                u32::from_le_bytes([isize_bytes[0], isize_bytes[1], isize_bytes[2], isize_bytes[3]])
+                    as usize
+            } else {
+                // Can't determine size — fall back to speculative decode.
+                let (start_bit, end_bit) = boundaries[0];
+                let chunk = speculative_decode(data, start_bit, end_bit, Some(&[]))?;
+                return Ok(Self { resolved_chunks: vec![chunk], next_index: 0 });
+            };
+
+            match decode_with_libdeflate(deflate_data, expected_size) {
+                Ok(decompressed) => {
+                    let mut chunk = ChunkData::new(header_size * 8);
+                    chunk.encoded_size = (deflate_end - header_size) * 8;
+                    chunk.append_resolved(decompressed);
+                    chunk.recompute_final_window();
+                    return Ok(Self { resolved_chunks: vec![chunk], next_index: 0 });
+                }
+                Err(_) => {
+                    // libdeflate failed (e.g. ISIZE overflow for >4GB files) — fall back.
+                    let (start_bit, end_bit) = boundaries[0];
+                    let chunk = speculative_decode(data, start_bit, end_bit, Some(&[]))?;
+                    return Ok(Self { resolved_chunks: vec![chunk], next_index: 0 });
+                }
+            }
+        }
+
+        // Parallel decode all chunks using a bounded work queue.
+        let num_chunks = boundaries.len();
+        let mut decoded_chunks: Vec<Option<std::result::Result<ChunkData, Error>>> =
+            (0..num_chunks).map(|_| None).collect();
+
+        let scope_result = crossbeam::scope(|scope| {
+            let (work_tx, work_rx) =
+                crossbeam::channel::bounded::<(usize, usize, usize, Option<Vec<u8>>)>(num_chunks);
+            let (result_tx, result_rx) = crossbeam::channel::bounded(num_threads * 2);
+
+            // Enqueue all work items.
+            for (idx, &(start_bit, end_bit)) in boundaries.iter().enumerate() {
+                let initial_window = if idx == 0 { Some(vec![]) } else { None };
+                work_tx.send((idx, start_bit, end_bit, initial_window)).unwrap();
+            }
+            drop(work_tx);
+
+            // Spawn exactly num_threads workers that pull from the work queue.
+            for _ in 0..num_threads {
+                let work_rx = work_rx.clone();
+                let result_tx = result_tx.clone();
+                scope.spawn(move |_| {
+                    while let Ok((idx, start_bit, end_bit, initial_window)) = work_rx.recv() {
+                        let window_ref = initial_window.as_deref();
+                        let result = speculative_decode(data, start_bit, end_bit, window_ref);
+                        let _ = result_tx.send((idx, result));
+                    }
+                });
+            }
+            drop(result_tx);
+
+            // Collect results.
+            for (idx, result) in result_rx {
+                decoded_chunks[idx] = Some(result);
+            }
+        });
+
+        // Handle crossbeam scope panics.
+        if let Err(e) = scope_result {
+            return Err(Error::Internal(format!("worker thread panicked: {e:?}")));
+        }
+
+        // Unwrap results, propagating the first error.
+        let mut chunks: Vec<ChunkData> = Vec::with_capacity(num_chunks);
+        for (i, slot) in decoded_chunks.into_iter().enumerate() {
+            match slot {
+                Some(Ok(chunk)) => chunks.push(chunk),
+                Some(Err(e)) => return Err(e),
+                None => {
+                    return Err(Error::Internal(format!("chunk {i} was not produced by workers")));
+                }
+            }
+        }
+
+        // Ensure chunk 0's final_window is correct after parallel decode.
+        if !chunks.is_empty() && chunks[0].is_resolved() {
+            chunks[0].recompute_final_window();
+        }
+
+        // Sequential marker resolution: resolve chunk K+1 using chunk K's final window.
+        for i in 1..chunks.len() {
+            let prev_window = chunks[i - 1]
+                .final_window
+                .clone()
+                .expect("speculative_decode must set final_window");
+            if !chunks[i].is_resolved() {
+                replace_markers(&mut chunks[i], &prev_window, false);
+            }
+        }
+
+        Ok(Self { resolved_chunks: chunks, next_index: 0 })
+    }
+
+    /// Create a fetcher from raw file data, automatically detecting multi-member gzip.
+    ///
+    /// For single-member files, uses the speculative parallel decode path.
+    /// Multi-member files should use [`decode_member_batch`] via the reader's
+    /// lazy batch decoding instead of pre-decoding everything here.
+    pub fn from_data(data: &[u8], config: FetcherConfig) -> Result<Self> {
+        let members = scan_gzip_members(data);
+
+        // Single member: parse header and delegate to the existing path.
+        if members.is_empty() {
+            return Err(Error::Internal("no gzip members found".into()));
+        }
+
+        let (start, end) = members[0];
+        let member_data = &data[start..end];
+        let mut cursor = std::io::Cursor::new(member_data);
+        let _header = GzipHeader::parse(&mut cursor)
+            .map_err(|e| Error::Internal(format!("gzip header: {e}")))?;
+        let header_size = start + cursor.position() as usize;
+
+        // Trailer is last 8 bytes of the member.
+        let deflate_end = end.saturating_sub(8);
+
+        Self::new(data, header_size, deflate_end, config)
+    }
+
+    /// Get the next resolved chunk, or `None` if all consumed.
+    pub fn next_chunk(&mut self) -> Option<ChunkData> {
+        if self.next_index < self.resolved_chunks.len() {
+            let chunk =
+                std::mem::replace(&mut self.resolved_chunks[self.next_index], ChunkData::new(0));
+            self.next_index += 1;
+            Some(chunk)
+        } else {
+            None
+        }
+    }
+}
+
+/// Check whether the bytes at `pos` in `data` look like a valid gzip member header.
+///
+/// Validates magic bytes (`0x1f 0x8b`), DEFLATE method (`0x08`), reserved flag
+/// bits (bits 5-7 must be zero), and attempts to parse the full header via
+/// [`GzipHeader::parse`].
+fn is_gzip_header(data: &[u8], pos: usize) -> bool {
+    if pos + 10 > data.len() {
+        return false;
+    }
+    // Magic + method
+    if data[pos] != 0x1f || data[pos + 1] != 0x8b || data[pos + 2] != 0x08 {
+        return false;
+    }
+    // Flags: bits 5-7 are reserved and must be zero.
+    let flags = data[pos + 3];
+    if flags & 0xE0 != 0 {
+        return false;
+    }
+    // Try to parse the full header (validates extra, filename, comment, CRC fields).
+    let mut cursor = std::io::Cursor::new(&data[pos..]);
+    GzipHeader::parse(&mut cursor).is_ok()
+}
+
+/// Scan file data for gzip member boundaries.
+///
+/// Returns a list of `(member_start, member_end)` byte offset pairs.
+/// Each member spans from its gzip header to the byte before the next member
+/// (or EOF).
+///
+/// Strategy: first try exact-match scanning using the first member's complete
+/// header bytes as a signature (fast, no false positives for pigz/bgzip where
+/// all members share identical headers). If the first exact-match scan finds
+/// only one member but the file is large, fall back to structural validation
+/// to handle heterogeneous headers.
+pub fn scan_gzip_members(data: &[u8]) -> Vec<(usize, usize)> {
+    if data.len() < 10 {
+        return vec![];
+    }
+
+    // Validate the first member.
+    if !is_gzip_header(data, 0) {
+        return vec![];
+    }
+
+    // Parse first header to get its exact length.
+    let mut cursor = std::io::Cursor::new(data);
+    let _header = match GzipHeader::parse(&mut cursor) {
+        Ok(h) => h,
+        Err(_) => return vec![],
+    };
+    let first_header_len = cursor.position() as usize;
+    let sig = &data[..first_header_len];
+
+    // Phase 1: exact-signature scan (fast, zero false positives for uniform headers).
+    let exact_members = scan_with_pattern(data, sig, first_header_len);
+
+    if exact_members.len() > 1 {
+        return exact_members;
+    }
+
+    // Phase 2: structural scan for heterogeneous members (different flags/timestamps).
+    let structural_members = scan_with_validator(data, first_header_len);
+
+    if structural_members.len() > exact_members.len() {
+        return structural_members;
+    }
+
+    exact_members
+}
+
+/// Scan for members using an exact byte pattern for the header.
+fn scan_with_pattern(data: &[u8], sig: &[u8], first_header_len: usize) -> Vec<(usize, usize)> {
+    let sig_len = sig.len();
+    let mut members = Vec::new();
+    let mut pos = 0;
+
+    loop {
+        let min_end = pos + first_header_len.max(10) + 8;
+        let search_start = min_end.min(data.len());
+
+        if search_start + sig_len > data.len() {
+            members.push((pos, data.len()));
+            break;
+        }
+
+        let search_region = &data[search_start..];
+        let mut search_offset = 0;
+        let mut next_member = data.len();
+
+        while let Some(found) = memchr::memchr(sig[0], &search_region[search_offset..]) {
+            let abs_pos = search_start + search_offset + found;
+            if abs_pos + sig_len <= data.len() && data[abs_pos..abs_pos + sig_len] == *sig {
+                next_member = abs_pos;
+                break;
+            }
+            search_offset += found + 1;
+        }
+
+        members.push((pos, next_member));
+        pos = next_member;
+
+        if next_member >= data.len() {
+            break;
+        }
+    }
+
+    members
+}
+
+/// Scan for members using structural validation (for heterogeneous headers).
+///
+/// This is the Phase 2 fallback scanner, used when the exact-pattern scanner
+/// (Phase 1) fails to find members.  It validates gzip magic bytes, DEFLATE
+/// method, reserved flags, and header parseability at each candidate position.
+///
+/// As a heuristic to reduce false positives, the preceding trailer's ISIZE
+/// field is required to be nonzero and <= 1 MiB.  This means members with an
+/// empty decompressed payload (`ISIZE == 0`) or very large decompressed sizes
+/// (`ISIZE > 1 MiB`, noting that ISIZE wraps at 4 GiB) will not be detected
+/// as boundaries by this scanner.  Uniform-header files (pigz, bgzip) are
+/// handled by the Phase 1 exact-pattern scanner where this limitation does not
+/// apply.  Any false-positive boundaries that slip through are caught by the
+/// merge-retry logic in [`decode_member_batch`].
+fn scan_with_validator(data: &[u8], first_header_len: usize) -> Vec<(usize, usize)> {
+    let mut members = Vec::new();
+    let mut pos = 0;
+
+    loop {
+        let min_end = pos + first_header_len.max(10) + 8;
+        let search_start = min_end.min(data.len());
+
+        if search_start + 10 > data.len() {
+            members.push((pos, data.len()));
+            break;
+        }
+
+        let search_region = &data[search_start..];
+        let mut search_offset = 0;
+        let mut next_member = data.len();
+
+        while let Some(found) = memchr::memchr(0x1f, &search_region[search_offset..]) {
+            let abs_pos = search_start + search_offset + found;
+
+            if is_gzip_header(data, abs_pos) && abs_pos >= pos + 18 {
+                // Additional validation: check that the ISIZE in the preceding
+                // trailer is plausible (nonzero and <= 1 MiB for typical members).
+                if abs_pos >= 4 {
+                    let isize_bytes = &data[abs_pos - 4..abs_pos];
+                    let isize_val = u32::from_le_bytes([
+                        isize_bytes[0],
+                        isize_bytes[1],
+                        isize_bytes[2],
+                        isize_bytes[3],
+                    ]);
+                    if isize_val > 0 && isize_val <= 1_048_576 {
+                        next_member = abs_pos;
+                        break;
+                    }
+                }
+            }
+            search_offset += found + 1;
+        }
+
+        members.push((pos, next_member));
+        pos = next_member;
+
+        if next_member >= data.len() {
+            break;
+        }
+    }
+
+    members
+}
+
+/// Decompress a batch of gzip members in parallel using libdeflate.
+///
+/// Each member is independent (fresh DEFLATE window), so they can be decoded
+/// concurrently without inter-member dependencies. Returns one [`ChunkData`]
+/// per member, in order.
+///
+/// If a candidate member fails to decompress (false-positive boundary), it is
+/// merged with the previous member and retried.
+pub fn decode_member_batch(
+    data: &[u8],
+    members: &[(usize, usize)],
+    num_threads: usize,
+    verify_crc: bool,
+) -> Result<Vec<ChunkData>> {
+    let num_threads = num_threads.max(1);
+    let num_members = members.len();
+
+    if num_members == 0 {
+        return Ok(vec![]);
+    }
+
+    let mut decoded_chunks: Vec<Option<std::result::Result<ChunkData, Error>>> =
+        (0..num_members).map(|_| None).collect();
+
+    let scope_result = crossbeam::scope(|scope| {
+        let (work_tx, work_rx) = crossbeam::channel::bounded::<(usize, usize, usize)>(num_members);
+        let (result_tx, result_rx) = crossbeam::channel::bounded(num_threads * 2);
+
+        // Enqueue all members.
+        for (idx, &(start, end)) in members.iter().enumerate() {
+            work_tx.send((idx, start, end)).unwrap();
+        }
+        drop(work_tx);
+
+        // Spawn worker threads.
+        for _ in 0..num_threads {
+            let work_rx = work_rx.clone();
+            let result_tx = result_tx.clone();
+            scope.spawn(move |_| {
+                let mut decompressor = libdeflater::Decompressor::new();
+                while let Ok((idx, start, end)) = work_rx.recv() {
+                    let result =
+                        decode_single_member(data, start, end, &mut decompressor, verify_crc);
+                    let _ = result_tx.send((idx, result));
+                }
+            });
+        }
+        drop(result_tx);
+
+        // Collect results.
+        for (idx, result) in result_rx {
+            decoded_chunks[idx] = Some(result);
+        }
+    });
+
+    if let Err(e) = scope_result {
+        return Err(Error::Internal(format!("worker thread panicked: {e:?}")));
+    }
+
+    // Unwrap results in order, merging failed members with the previous member
+    // (false-positive boundary detection).
+    let mut chunks: Vec<ChunkData> = Vec::with_capacity(num_members);
+
+    for (i, slot) in decoded_chunks.into_iter().enumerate() {
+        match slot {
+            Some(Ok(chunk)) => {
+                chunks.push(chunk);
+            }
+            Some(Err(_e)) => {
+                // This member failed to decompress — likely a false-positive boundary.
+                // Merge it with the previous member by extending the previous member's
+                // range and re-decoding.
+                if chunks.is_empty() {
+                    // First member failed — cannot merge.
+                    return Err(_e);
+                }
+                let (_failed_start, failed_end) = members[i];
+                let prev_offset = chunks.last().unwrap().encoded_offset / 8;
+                let mut decompressor = libdeflater::Decompressor::new();
+                match decode_single_member(
+                    data,
+                    prev_offset,
+                    failed_end,
+                    &mut decompressor,
+                    verify_crc,
+                ) {
+                    Ok(merged) => {
+                        *chunks.last_mut().unwrap() = merged;
+                    }
+                    Err(e2) => return Err(e2),
+                }
+            }
+            None => {
+                return Err(Error::Internal(format!("member {i} was not produced by workers")));
+            }
+        }
+    }
+
+    Ok(chunks)
+}
+
+/// Decompress a single gzip member using libdeflate.
+///
+/// Parses the gzip header, extracts DEFLATE data between the header and 8-byte
+/// trailer, reads ISIZE from the trailer, decompresses with libdeflate, and
+/// optionally verifies the CRC32 checksum.
+fn decode_single_member(
+    data: &[u8],
+    start: usize,
+    end: usize,
+    decompressor: &mut libdeflater::Decompressor,
+    verify_crc: bool,
+) -> Result<ChunkData> {
+    let member_data = &data[start..end];
+
+    // Parse header.
+    let mut cursor = std::io::Cursor::new(member_data);
+    let _header = GzipHeader::parse(&mut cursor)
+        .map_err(|e| Error::Internal(format!("member at {start} header: {e}")))?;
+    let header_len = cursor.position() as usize;
+
+    // DEFLATE data is between header and 8-byte trailer (CRC32 + ISIZE).
+    if member_data.len() < header_len + 8 {
+        return Err(Error::Internal(format!(
+            "member at {start} too short: {} bytes, need at least {}",
+            member_data.len(),
+            header_len + 8
+        )));
+    }
+    let deflate_data = &member_data[header_len..member_data.len() - 8];
+
+    // Parse trailer: first 4 bytes = CRC32, last 4 bytes = ISIZE.
+    let trailer = &member_data[member_data.len() - 8..];
+    let stored_crc = u32::from_le_bytes([trailer[0], trailer[1], trailer[2], trailer[3]]);
+    // ISIZE is the original size mod 2^32, so it wraps for files >4 GiB.
+    // An incorrect size hint causes libdeflate to fail with a size mismatch,
+    // which is surfaced as an error to the caller.
+    let isize_val = u32::from_le_bytes([trailer[4], trailer[5], trailer[6], trailer[7]]) as usize;
+
+    // Decompress with libdeflate.
+    let mut output = vec![0u8; isize_val];
+    let actual = decompressor
+        .deflate_decompress(deflate_data, &mut output)
+        .map_err(|e| Error::Internal(format!("member at {start} decompress: {e}")))?;
+    output.truncate(actual);
+
+    // Verify CRC32 if requested.
+    if verify_crc {
+        let computed_crc = crc32fast::hash(&output);
+        if computed_crc != stored_crc {
+            return Err(Error::Crc32Mismatch { expected: stored_crc, found: computed_crc });
+        }
+    }
+
+    let mut chunk = ChunkData::new(start * 8);
+    chunk.encoded_size = (end - start) * 8;
+    chunk.append_resolved(output);
+    chunk.recompute_final_window();
+    Ok(chunk)
+}
+
+/// Generate chunk boundaries as `(start_bit, end_bit)` pairs.
+///
+/// Each boundary is a valid DEFLATE block start found by the block scanner.
+/// The first chunk starts at the known DEFLATE beginning (after gzip header)
+/// and subsequent splits are found by scanning near each `chunk_size` interval.
+fn generate_boundaries(
+    data: &[u8],
+    header_size: usize,
+    deflate_end: usize,
+    chunk_size: usize,
+) -> Vec<(usize, usize)> {
+    let start_bit = header_size * 8;
+    let end_bit = deflate_end * 8;
+
+    if end_bit <= start_bit {
+        return vec![];
+    }
+
+    let total_bytes = deflate_end - header_size;
+    if total_bytes <= chunk_size {
+        return vec![(start_bit, end_bit)];
+    }
+
+    let mut boundaries = vec![];
+    let mut current_start = start_bit;
+    let mut byte_offset = header_size;
+
+    loop {
+        let next_byte = byte_offset + chunk_size;
+
+        if next_byte >= deflate_end {
+            // Last chunk: extends to the end of DEFLATE data.
+            boundaries.push((current_start, end_bit));
+            break;
+        }
+
+        // Scan up to 1 MiB past the target split point for a valid block boundary.
+        let scan_start_bit = next_byte * 8;
+        let scan_limit = (next_byte + 1024 * 1024).min(deflate_end);
+        let scan_end_bit = scan_limit * 8;
+
+        match scan_for_block(data, scan_start_bit, scan_end_bit) {
+            Some(BlockBoundary { bit_offset }) => {
+                boundaries.push((current_start, bit_offset));
+                current_start = bit_offset;
+                byte_offset = bit_offset / 8;
+            }
+            None => {
+                // No boundary found in the scan range. Extend the search window
+                // by advancing one more chunk_size and trying again.
+                byte_offset = scan_limit;
+                if byte_offset >= deflate_end {
+                    boundaries.push((current_start, end_bit));
+                    break;
+                }
+            }
+        }
+    }
+
+    // Safety: ensure the last boundary reaches the end.
+    if let Some(last) = boundaries.last_mut() {
+        if last.1 < end_bit {
+            last.1 = end_bit;
+        }
+    }
+
+    boundaries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gzip_compress(data: &[u8]) -> Vec<u8> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+        let mut e = GzEncoder::new(Vec::new(), Compression::default());
+        e.write_all(data).unwrap();
+        e.finish().unwrap()
+    }
+
+    fn parse_header_size(gzip_data: &[u8]) -> usize {
+        use crate::gzip::GzipHeader;
+        let mut cursor = std::io::Cursor::new(gzip_data);
+        let _header = GzipHeader::parse(&mut cursor).unwrap();
+        cursor.position() as usize
+    }
+
+    #[test]
+    fn test_single_chunk_small_data() {
+        let original = b"Hello, world!";
+        let compressed = gzip_compress(original);
+        let header_size = parse_header_size(&compressed);
+        let deflate_end = compressed.len().saturating_sub(8);
+        let config = FetcherConfig { threads: 2, chunk_size: 4 * 1024 * 1024, verify_crc: true };
+        let mut fetcher = ChunkFetcher::new(&compressed, header_size, deflate_end, config).unwrap();
+
+        let chunk = fetcher.next_chunk().expect("should have one chunk");
+        assert!(chunk.is_resolved());
+
+        let output: Vec<u8> =
+            chunk.resolved_data().iter().flat_map(|b| b.iter().copied()).collect();
+        assert_eq!(output, original.as_slice());
+        assert!(fetcher.next_chunk().is_none());
+    }
+
+    #[test]
+    fn test_scan_single_member() {
+        let compressed = gzip_compress(b"hello");
+        let members = scan_gzip_members(&compressed);
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0], (0, compressed.len()));
+    }
+
+    #[test]
+    fn test_scan_multi_member() {
+        let mut data = gzip_compress(b"first");
+        let first_len = data.len();
+        data.extend_from_slice(&gzip_compress(b"second"));
+        let members = scan_gzip_members(&data);
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0], (0, first_len));
+        assert_eq!(members[1], (first_len, data.len()));
+    }
+
+    #[test]
+    fn test_scan_empty() {
+        let members = scan_gzip_members(&[]);
+        assert!(members.is_empty());
+    }
+
+    #[test]
+    fn test_from_data_single_member() {
+        let original = b"Hello from from_data!";
+        let compressed = gzip_compress(original);
+        let config = FetcherConfig { threads: 2, chunk_size: 4 * 1024 * 1024, verify_crc: true };
+        let mut fetcher = ChunkFetcher::from_data(&compressed, config).unwrap();
+        let chunk = fetcher.next_chunk().expect("should have one chunk");
+        let output: Vec<u8> =
+            chunk.resolved_data().iter().flat_map(|b| b.iter().copied()).collect();
+        assert_eq!(output, original.as_slice());
+    }
+
+    #[test]
+    fn test_decode_member_batch() {
+        let mut data = gzip_compress(b"alpha");
+        data.extend_from_slice(&gzip_compress(b"beta"));
+        data.extend_from_slice(&gzip_compress(b"gamma"));
+        let members = scan_gzip_members(&data);
+        assert_eq!(members.len(), 3);
+
+        let chunks = decode_member_batch(&data, &members, 2, true).unwrap();
+        assert_eq!(chunks.len(), 3);
+
+        let mut output = Vec::new();
+        for chunk in &chunks {
+            for buf in chunk.resolved_data() {
+                output.extend_from_slice(buf);
+            }
+        }
+        assert_eq!(output, b"alphabetagamma");
+    }
+
+    #[test]
+    fn test_decode_member_batch_crc_verification() {
+        let data = gzip_compress(b"hello crc");
+        let members = scan_gzip_members(&data);
+        assert_eq!(members.len(), 1);
+
+        // With verification enabled — should succeed.
+        let chunks = decode_member_batch(&data, &members, 1, true).unwrap();
+        assert_eq!(chunks.len(), 1);
+
+        // Corrupt the CRC32 in the trailer (bytes at end-8..end-4).
+        let mut corrupted = data.clone();
+        let crc_pos = corrupted.len() - 8;
+        corrupted[crc_pos] ^= 0xFF;
+
+        // With verification enabled — should fail.
+        let result = decode_member_batch(&corrupted, &[(0, corrupted.len())], 1, true);
+        assert!(result.is_err());
+
+        // With verification disabled — should succeed despite corruption.
+        let result = decode_member_batch(&corrupted, &[(0, corrupted.len())], 1, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_scan_heterogeneous_members() {
+        // Create members with different compression levels (different XFL byte).
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let mut member1 = Vec::new();
+        {
+            let mut e = GzEncoder::new(&mut member1, Compression::fast());
+            e.write_all(b"fast member").unwrap();
+            e.finish().unwrap();
+        }
+        let mut member2 = Vec::new();
+        {
+            let mut e = GzEncoder::new(&mut member2, Compression::best());
+            e.write_all(b"best member").unwrap();
+            e.finish().unwrap();
+        }
+
+        let mut data = member1.clone();
+        let first_len = data.len();
+        data.extend_from_slice(&member2);
+
+        let members = scan_gzip_members(&data);
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0], (0, first_len));
+        assert_eq!(members[1], (first_len, data.len()));
+    }
+
+    #[test]
+    fn test_empty_boundaries() {
+        let boundaries = generate_boundaries(&[], 0, 0, 1024);
+        assert!(boundaries.is_empty());
+    }
+
+    #[test]
+    fn test_small_data_single_boundary() {
+        let original = b"small";
+        let compressed = gzip_compress(original);
+        let header_size = parse_header_size(&compressed);
+        let deflate_end = compressed.len().saturating_sub(8);
+
+        let boundaries =
+            generate_boundaries(&compressed, header_size, deflate_end, 4 * 1024 * 1024);
+        assert_eq!(boundaries.len(), 1);
+        assert_eq!(boundaries[0].0, header_size * 8);
+        assert_eq!(boundaries[0].1, deflate_end * 8);
+    }
+}

--- a/src/reader/marker.rs
+++ b/src/reader/marker.rs
@@ -1,0 +1,191 @@
+/// Maximum DEFLATE sliding window size in bytes.
+const MAX_WINDOW_SIZE: u16 = 32_768;
+
+/// A 16-bit value encoding either a literal byte or a reference into the preceding window.
+///
+/// The encoding scheme partitions the `u16` range as follows:
+/// - `0..=255`: literal byte value (the byte itself)
+/// - `256..=32767`: reserved/invalid
+/// - `32768..=65535`: window reference at offset `value - 32768`
+///
+/// During speculative DEFLATE decoding, back-references that fall into the unknown
+/// preceding window are stored as marker values.  Once the true window becomes
+/// available the markers are resolved to concrete bytes via [`MarkerValue::resolve`]
+/// or in bulk via [`apply_window`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MarkerValue(u16);
+
+impl MarkerValue {
+    /// Create a marker representing a literal byte value.
+    #[inline]
+    pub fn literal(byte: u8) -> Self {
+        Self(byte as u16)
+    }
+
+    /// Create a marker representing a reference into the preceding window.
+    ///
+    /// `offset` must be in `0..MAX_WINDOW_SIZE` (i.e. `0..32768`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `offset >= MAX_WINDOW_SIZE`.
+    #[inline]
+    pub fn window_ref(offset: u16) -> Self {
+        assert!(offset < MAX_WINDOW_SIZE, "window offset out of range: {offset}");
+        Self(offset + MAX_WINDOW_SIZE)
+    }
+
+    /// Returns `true` if this value encodes a literal byte.
+    #[inline]
+    pub fn is_literal(self) -> bool {
+        self.0 <= 255
+    }
+
+    /// Returns `true` if this value encodes a window reference.
+    #[inline]
+    pub fn is_marker(self) -> bool {
+        self.0 >= MAX_WINDOW_SIZE
+    }
+
+    /// Resolve this value to a concrete byte.
+    ///
+    /// Literals return the byte directly.  Window references index into the
+    /// provided `window` slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is a window reference and the offset is out of bounds for `window`,
+    /// or if the value is in the reserved range (`256..32768`).
+    #[inline]
+    pub fn resolve(self, window: &[u8]) -> u8 {
+        if self.is_literal() {
+            self.0 as u8
+        } else if self.is_marker() {
+            let offset = (self.0 - MAX_WINDOW_SIZE) as usize;
+            window[offset]
+        } else {
+            panic!("MarkerValue in reserved range: {}", self.0);
+        }
+    }
+}
+
+/// Resolve a slice of marker values into concrete bytes.
+///
+/// Each element of `markers` is resolved against `window` and written to the
+/// corresponding position in `output`.
+///
+/// # Panics
+///
+/// Panics if `output.len() < markers.len()`, or if any marker cannot be resolved
+/// (see [`MarkerValue::resolve`]).
+#[inline]
+pub fn apply_window(markers: &[MarkerValue], window: &[u8], output: &mut [u8]) {
+    assert!(output.len() >= markers.len(), "output buffer too small for marker resolution");
+    for (i, &marker) in markers.iter().enumerate() {
+        output[i] = marker.resolve(window);
+    }
+}
+
+/// Returns `true` if any element in `markers` is a window reference.
+///
+/// A slice consisting entirely of literals returns `false`, meaning no window
+/// resolution is needed.
+#[inline]
+pub fn contains_markers(markers: &[MarkerValue]) -> bool {
+    markers.iter().any(|m| m.is_marker())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_literal_roundtrip() {
+        for byte in 0..=255u8 {
+            let mv = MarkerValue::literal(byte);
+            assert!(mv.is_literal(), "byte {byte} should be literal");
+            assert!(!mv.is_marker(), "byte {byte} should not be marker");
+            assert_eq!(mv.resolve(&[]), byte, "literal {byte} should resolve to itself");
+        }
+    }
+
+    #[test]
+    fn test_window_ref() {
+        let window: Vec<u8> = (0..=255).cycle().take(MAX_WINDOW_SIZE as usize).collect();
+
+        // Test offset 0
+        let mv = MarkerValue::window_ref(0);
+        assert!(!mv.is_literal());
+        assert!(mv.is_marker());
+        assert_eq!(mv.resolve(&window), window[0]);
+
+        // Test offset 1
+        let mv = MarkerValue::window_ref(1);
+        assert_eq!(mv.resolve(&window), window[1]);
+
+        // Test maximum valid offset
+        let max_offset = MAX_WINDOW_SIZE - 1;
+        let mv = MarkerValue::window_ref(max_offset);
+        assert!(mv.is_marker());
+        assert_eq!(mv.resolve(&window), window[max_offset as usize]);
+
+        // Test a mid-range offset
+        let mv = MarkerValue::window_ref(1000);
+        assert_eq!(mv.resolve(&window), window[1000]);
+    }
+
+    #[test]
+    fn test_apply_window() {
+        let window: Vec<u8> = vec![10, 20, 30, 40, 50];
+        let markers = vec![
+            MarkerValue::literal(0xFF),
+            MarkerValue::window_ref(2),
+            MarkerValue::literal(0x42),
+            MarkerValue::window_ref(0),
+            MarkerValue::window_ref(4),
+        ];
+        let mut output = vec![0u8; markers.len()];
+        apply_window(&markers, &window, &mut output);
+        assert_eq!(output, vec![0xFF, 30, 0x42, 10, 50]);
+    }
+
+    #[test]
+    fn test_contains_markers() {
+        // All literals — no markers
+        let all_literals =
+            vec![MarkerValue::literal(0), MarkerValue::literal(128), MarkerValue::literal(255)];
+        assert!(!contains_markers(&all_literals));
+
+        // Mixed — contains markers
+        let mixed = vec![MarkerValue::literal(0), MarkerValue::window_ref(0)];
+        assert!(contains_markers(&mixed));
+
+        // All markers
+        let all_markers = vec![MarkerValue::window_ref(0), MarkerValue::window_ref(100)];
+        assert!(contains_markers(&all_markers));
+
+        // Empty slice
+        assert!(!contains_markers(&[]));
+    }
+
+    #[test]
+    fn test_edge_offsets() {
+        let window = vec![0xAA; MAX_WINDOW_SIZE as usize];
+
+        // Offset 0 (minimum)
+        let mv = MarkerValue::window_ref(0);
+        assert_eq!(mv.resolve(&window), 0xAA);
+
+        // Offset MAX_WINDOW_SIZE - 1 (maximum valid)
+        let mv = MarkerValue::window_ref(MAX_WINDOW_SIZE - 1);
+        assert_eq!(mv.resolve(&window), 0xAA);
+    }
+
+    #[test]
+    #[should_panic(expected = "reserved range")]
+    fn test_reserved_range_panics() {
+        // Construct a value in the reserved range (256..32768) manually
+        let mv = MarkerValue(256);
+        mv.resolve(&[]);
+    }
+}

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1,0 +1,226 @@
+//! Parallel gzip reader using speculative decode with marker-based window resolution.
+//!
+//! This module implements rapidgzip-style parallel decompression:
+//! 1. Speculatively decode DEFLATE chunks without knowing the previous 32KB window
+//! 2. Encode unknown back-references as 16-bit markers
+//! 3. Replace markers in parallel once the window becomes available
+
+mod chunk;
+mod fetcher;
+mod marker;
+mod replacer;
+mod speculative;
+mod window_map;
+
+pub use chunk::ChunkData;
+pub use fetcher::{ChunkFetcher, FetcherConfig};
+pub use marker::{apply_window, contains_markers, MarkerValue};
+pub use replacer::replace_markers;
+pub use speculative::{decode_with_libdeflate, speculative_decode};
+pub use window_map::WindowMap;
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::{self, BufReader, Read};
+use std::path::Path;
+
+/// Parallel gzip reader that transparently decompresses using multiple threads.
+///
+/// For regular files, the input is memory-mapped and split into chunks that are
+/// decoded in parallel via speculative DEFLATE decompression. For non-seekable
+/// inputs (pipes, sockets), falls back to single-threaded streaming via flate2.
+///
+/// Multi-member gzip files are decompressed in batches to cap peak memory usage.
+/// Only `batch_size` members are decompressed at a time; completed batches are
+/// freed as they are consumed by the caller.
+pub struct ParallelGzipReader {
+    inner: ReaderInner,
+    buffer: Vec<u8>,
+    buffer_pos: usize,
+}
+
+enum ReaderInner {
+    /// Multi-member gzip: decompress batches of members on demand.
+    MultiMember {
+        /// Memory-mapped file data (kept alive for the reader's lifetime).
+        mmap: memmap2::Mmap,
+        /// Byte-offset boundaries for each member: `(start, end)`.
+        members: Vec<(usize, usize)>,
+        /// Index of the next member to start decoding in the next batch.
+        next_batch_start: usize,
+        /// Number of members to decode per batch.
+        batch_size: usize,
+        /// Number of worker threads.
+        num_threads: usize,
+        /// Whether to verify CRC32 after decompression.
+        verify_crc: bool,
+        /// Decoded chunks waiting to be consumed (FIFO).
+        pending_chunks: VecDeque<ChunkData>,
+    },
+    /// Single-member gzip: all chunks pre-decoded via speculative parallel decode.
+    SingleMember {
+        /// Memory map kept alive for safety.
+        _mmap: memmap2::Mmap,
+        /// Pre-decoded chunk fetcher.
+        fetcher: fetcher::ChunkFetcher,
+    },
+    /// Streaming fallback (pipes, sockets).
+    Streaming(Box<dyn Read + Send>),
+}
+
+impl ParallelGzipReader {
+    /// Create from a file path.
+    ///
+    /// Memory-maps the file if it is a regular file with nonzero size, otherwise
+    /// falls back to streaming decompression. Multi-member gzip files (e.g. from
+    /// `pigz`) are detected automatically and each member is decompressed lazily
+    /// in parallel batches to cap peak memory usage.
+    ///
+    /// # Arguments
+    /// * `path` - path to the gzip file
+    /// * `threads` - number of worker threads (0 = auto-detect)
+    pub fn from_file<P: AsRef<Path>>(path: P, threads: usize) -> io::Result<Self> {
+        let file = File::open(path.as_ref())?;
+        let metadata = file.metadata()?;
+
+        if metadata.is_file() && metadata.len() > 0 {
+            // Safety: the file is a regular file that we keep open for the lifetime
+            // of the mmap. We do not write to the mmap.
+            let mmap = unsafe { memmap2::Mmap::map(&file)? };
+
+            let threads = if threads == 0 { num_cpus::get() } else { threads };
+            let config = FetcherConfig { threads, chunk_size: 4 * 1024 * 1024, verify_crc: true };
+
+            let members = fetcher::scan_gzip_members(mmap.as_ref());
+
+            if members.len() > 1 {
+                // Multi-member: set up lazy batch decoding.
+                let batch_size = threads * 64;
+                Ok(Self {
+                    inner: ReaderInner::MultiMember {
+                        mmap,
+                        members,
+                        next_batch_start: 0,
+                        batch_size,
+                        num_threads: threads,
+                        verify_crc: config.verify_crc,
+                        pending_chunks: VecDeque::new(),
+                    },
+                    buffer: Vec::new(),
+                    buffer_pos: 0,
+                })
+            } else {
+                // Single member: pre-decode everything via speculative decode.
+                let fetcher = fetcher::ChunkFetcher::from_data(mmap.as_ref(), config)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+                Ok(Self {
+                    inner: ReaderInner::SingleMember { _mmap: mmap, fetcher },
+                    buffer: Vec::new(),
+                    buffer_pos: 0,
+                })
+            }
+        } else {
+            Self::from_reader(file, threads)
+        }
+    }
+
+    /// Create from any `Read` source (streaming fallback with flate2).
+    ///
+    /// The `_threads` parameter is accepted for API symmetry but ignored;
+    /// streaming decompression is single-threaded.
+    pub fn from_reader<R: Read + Send + 'static>(reader: R, _threads: usize) -> io::Result<Self> {
+        let decoder = flate2::read::MultiGzDecoder::new(BufReader::new(reader));
+        Ok(Self {
+            inner: ReaderInner::Streaming(Box::new(decoder)),
+            buffer: Vec::new(),
+            buffer_pos: 0,
+        })
+    }
+}
+
+impl Read for ParallelGzipReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // Drain current buffer first.
+        if self.buffer_pos < self.buffer.len() {
+            let available = self.buffer.len() - self.buffer_pos;
+            let to_copy = available.min(buf.len());
+            buf[..to_copy]
+                .copy_from_slice(&self.buffer[self.buffer_pos..self.buffer_pos + to_copy]);
+            self.buffer_pos += to_copy;
+            return Ok(to_copy);
+        }
+
+        match &mut self.inner {
+            ReaderInner::MultiMember {
+                mmap,
+                members,
+                next_batch_start,
+                batch_size,
+                num_threads,
+                verify_crc,
+                pending_chunks,
+            } => {
+                // Try to find the next non-empty chunk, fetching new batches as needed.
+                loop {
+                    // Drain pending chunks, skipping empty ones.
+                    while let Some(mut chunk) = pending_chunks.pop_front() {
+                        self.buffer.clear();
+                        for segment in chunk.take_output() {
+                            self.buffer.extend_from_slice(&segment);
+                        }
+                        if !self.buffer.is_empty() {
+                            self.buffer_pos = 0;
+                            let to_copy = self.buffer.len().min(buf.len());
+                            buf[..to_copy].copy_from_slice(&self.buffer[..to_copy]);
+                            self.buffer_pos = to_copy;
+                            return Ok(to_copy);
+                        }
+                    }
+
+                    // No pending chunks — decode the next batch.
+                    if *next_batch_start >= members.len() {
+                        return Ok(0); // EOF
+                    }
+
+                    let batch_end = (*next_batch_start + *batch_size).min(members.len());
+                    let batch_members = &members[*next_batch_start..batch_end];
+
+                    let new_chunks = fetcher::decode_member_batch(
+                        mmap.as_ref(),
+                        batch_members,
+                        *num_threads,
+                        *verify_crc,
+                    )
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+                    *next_batch_start = batch_end;
+                    pending_chunks.extend(new_chunks);
+                }
+            }
+            ReaderInner::SingleMember { fetcher, .. } => {
+                loop {
+                    match fetcher.next_chunk() {
+                        Some(mut chunk) => {
+                            // Flatten chunk output into buffer.
+                            self.buffer.clear();
+                            for segment in chunk.take_output() {
+                                self.buffer.extend_from_slice(&segment);
+                            }
+                            if !self.buffer.is_empty() {
+                                self.buffer_pos = 0;
+                                let to_copy = self.buffer.len().min(buf.len());
+                                buf[..to_copy].copy_from_slice(&self.buffer[..to_copy]);
+                                self.buffer_pos = to_copy;
+                                return Ok(to_copy);
+                            }
+                            // Empty chunk — continue to next
+                        }
+                        None => return Ok(0),
+                    }
+                }
+            }
+            ReaderInner::Streaming(reader) => reader.read(buf),
+        }
+    }
+}

--- a/src/reader/replacer.rs
+++ b/src/reader/replacer.rs
@@ -1,0 +1,102 @@
+//! Marker replacement for speculative decode chunks.
+
+use super::chunk::ChunkData;
+
+/// Resolve all markers in a chunk and optionally compute CRC32.
+///
+/// Called when the previous chunk completes and its final window is available.
+/// After this call, `chunk.is_resolved()` returns true.
+///
+/// If `compute_crc` is true, also computes and stores the CRC32 of the
+/// resolved data in `chunk.crc32`.
+pub fn replace_markers(chunk: &mut ChunkData, window: &[u8], compute_crc: bool) {
+    chunk.resolve_markers(window);
+    chunk.recompute_final_window();
+
+    if compute_crc {
+        let mut hasher = crc32fast::Hasher::new();
+        for buf in chunk.resolved_data() {
+            hasher.update(buf);
+        }
+        chunk.crc32 = Some(hasher.finalize());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reader::marker::MarkerValue;
+
+    #[test]
+    fn test_replace_markers_basic() {
+        let mut chunk = ChunkData::new(0);
+        // Mix of resolved data and marker data referencing the window.
+        chunk.append_resolved(vec![0x01, 0x02]);
+        chunk.append_markers(vec![
+            MarkerValue::literal(0xFF),
+            MarkerValue::window_ref(0),
+            MarkerValue::window_ref(2),
+        ]);
+        assert!(!chunk.is_resolved());
+
+        let window = vec![0xAA, 0xBB, 0xCC];
+        replace_markers(&mut chunk, &window, false);
+
+        assert!(chunk.is_resolved());
+        assert!(chunk.crc32.is_none());
+
+        // Verify resolved data: original resolved buf + resolved markers buf.
+        let data = chunk.resolved_data();
+        assert_eq!(data[0], vec![0x01, 0x02]);
+        assert_eq!(data[1], vec![0xFF, 0xAA, 0xCC]);
+
+        // final_window should be recomputed — always 32KB, zero-padded at the front.
+        assert!(chunk.final_window.is_some());
+        let fw = chunk.final_window.as_ref().unwrap();
+        let expected_data = [0x01u8, 0x02, 0xFF, 0xAA, 0xCC];
+        assert_eq!(fw.len(), 32768);
+        assert_eq!(&fw[32768 - expected_data.len()..], &expected_data);
+    }
+
+    #[test]
+    fn test_replace_markers_with_crc() {
+        let mut chunk = ChunkData::new(0);
+        chunk.append_markers(vec![MarkerValue::window_ref(0), MarkerValue::literal(0x42)]);
+
+        let window = vec![0x10, 0x20, 0x30];
+        replace_markers(&mut chunk, &window, true);
+
+        assert!(chunk.is_resolved());
+        assert!(chunk.crc32.is_some());
+
+        // Compute the expected CRC32 independently.
+        let resolved_bytes = vec![0x10u8, 0x42];
+        let expected_crc = {
+            let mut h = crc32fast::Hasher::new();
+            h.update(&resolved_bytes);
+            h.finalize()
+        };
+        assert_eq!(chunk.crc32.unwrap(), expected_crc);
+    }
+
+    #[test]
+    fn test_replace_no_markers() {
+        let mut chunk = ChunkData::new(0);
+        chunk.append_resolved(vec![0xDE, 0xAD, 0xBE, 0xEF]);
+
+        // Already resolved — replace_markers should be a no-op on the data.
+        assert!(chunk.is_resolved());
+        let window = vec![];
+        replace_markers(&mut chunk, &window, false);
+
+        assert!(chunk.is_resolved());
+        assert!(chunk.crc32.is_none());
+        assert_eq!(chunk.resolved_data(), &[vec![0xDE, 0xAD, 0xBE, 0xEF]]);
+
+        // final_window should still be recomputed — always 32KB, zero-padded at the front.
+        let fw = chunk.final_window.as_ref().unwrap();
+        let expected_data = [0xDEu8, 0xAD, 0xBE, 0xEF];
+        assert_eq!(fw.len(), 32768);
+        assert_eq!(&fw[32768 - expected_data.len()..], &expected_data);
+    }
+}

--- a/src/reader/speculative.rs
+++ b/src/reader/speculative.rs
@@ -1,0 +1,714 @@
+//! Speculative DEFLATE decoder that emits markers for unknown back-references.
+//!
+//! During parallel gzip decompression, chunks are decoded without the preceding
+//! 32KB sliding window.  Back-references that fall into this unknown region are
+//! encoded as [`MarkerValue::window_ref`] entries.  When the window is known
+//! (either because the chunk is the first in the stream or because a previous
+//! chunk has been resolved), all references are resolved directly.
+
+use super::chunk::ChunkData;
+use super::marker::MarkerValue;
+use crate::bits::{BitRead, SliceBitReader};
+use crate::deflate::parser::parse_dynamic_huffman_tables;
+use crate::deflate::tables::{DISTANCE_TABLE, LENGTH_TABLE};
+use crate::error::{Error, Result};
+use crate::huffman::HuffmanDecoder;
+
+/// Maximum DEFLATE sliding window size in bytes (32KB).
+const WINDOW_SIZE: usize = 32_768;
+
+/// Speculatively decode a DEFLATE stream, emitting markers for unknown window references.
+///
+/// When `initial_window` is `None`, back-references that reach before the start of this
+/// chunk are encoded as `MarkerValue::window_ref()`.  When a window is provided, all
+/// references can be resolved immediately.
+///
+/// # Arguments
+/// * `data` - the full compressed file data (e.g. mmap'd)
+/// * `start_bit` - bit offset where DEFLATE data starts for this chunk
+/// * `end_bit` - bit offset to stop decoding (may be approximate; ignored once a final
+///   block is seen)
+/// * `initial_window` - if `Some`, the known 32KB window (all refs resolvable)
+pub fn speculative_decode(
+    data: &[u8],
+    start_bit: usize,
+    end_bit: usize,
+    initial_window: Option<&[u8]>,
+) -> Result<ChunkData> {
+    let byte_pos = start_bit / 8;
+    let bit_offset = (start_bit % 8) as u8;
+
+    let mut bits = SliceBitReader::new(data);
+    bits.set_bit_position(byte_pos, bit_offset);
+
+    let mut chunk = ChunkData::new(start_bit);
+
+    // The output buffer holds MarkerValues so we can track which positions are
+    // resolved bytes vs unknown window references.
+    let mut output: Vec<MarkerValue> = Vec::with_capacity(65_536);
+
+    // Circular window buffer for resolving within-chunk references.
+    // When initial_window is provided, prepopulate it.
+    let mut window = vec![MarkerValue::literal(0); WINDOW_SIZE];
+    let mut window_pos: usize = 0; // next write position in circular buffer
+
+    if let Some(init) = initial_window {
+        // Copy the initial window into our circular buffer.
+        // The window may be shorter than WINDOW_SIZE (e.g. start of stream).
+        let start = if init.len() >= WINDOW_SIZE { init.len() - WINDOW_SIZE } else { 0 };
+        let relevant = &init[start..];
+        for (i, &b) in relevant.iter().enumerate() {
+            window[i] = MarkerValue::literal(b);
+        }
+        window_pos = relevant.len() % WINDOW_SIZE;
+    }
+
+    // Total bytes of output produced (used to determine if a back-reference
+    // reaches into the unknown preceding window).
+    let initial_window_len = initial_window.map_or(0, |w| w.len().min(WINDOW_SIZE));
+    let mut total_output: usize = 0;
+
+    loop {
+        // Check if we've passed the end boundary (and we're not mid-block).
+        let current_bit = {
+            let (bp, bo) = bits.bit_position();
+            bp * 8 + bo as usize
+        };
+        if current_bit >= end_bit {
+            break;
+        }
+
+        // Read block header.
+        let is_final = bits.read_bit()?;
+        let block_type = bits.read_bits(2)? as u8;
+
+        match block_type {
+            0 => {
+                // Stored (uncompressed) block
+                decode_stored_block(
+                    &mut bits,
+                    &mut output,
+                    &mut window,
+                    &mut window_pos,
+                    &mut total_output,
+                )?;
+            }
+            1 => {
+                // Fixed Huffman codes
+                let lit_decoder = HuffmanDecoder::fixed_literal_length();
+                let dist_decoder = HuffmanDecoder::fixed_distance();
+                decode_huffman_block(
+                    &mut bits,
+                    &lit_decoder,
+                    Some(&dist_decoder),
+                    initial_window.is_some(),
+                    initial_window_len,
+                    &mut output,
+                    &mut window,
+                    &mut window_pos,
+                    &mut total_output,
+                )?;
+            }
+            2 => {
+                // Dynamic Huffman codes
+                let (lit_decoder, dist_decoder) = parse_dynamic_huffman_tables(&mut bits)?;
+                decode_huffman_block(
+                    &mut bits,
+                    &lit_decoder,
+                    dist_decoder.as_ref(),
+                    initial_window.is_some(),
+                    initial_window_len,
+                    &mut output,
+                    &mut window,
+                    &mut window_pos,
+                    &mut total_output,
+                )?;
+            }
+            _ => return Err(Error::InvalidBlockType(block_type)),
+        }
+
+        if is_final {
+            break;
+        }
+    }
+
+    // Compute encoded size in bits.
+    let final_bit = {
+        let (bp, bo) = bits.bit_position();
+        bp * 8 + bo as usize
+    };
+    chunk.encoded_size = final_bit.saturating_sub(start_bit);
+
+    // Set the final window (last 32KB of output) for resolving the next chunk.
+    let final_win = extract_final_window(&window, window_pos, total_output);
+    chunk.final_window = Some(final_win);
+
+    // Split output into resolved and marker segments.
+    flush_output(&mut chunk, &output);
+
+    Ok(chunk)
+}
+
+/// Decode a stored (uncompressed) DEFLATE block.
+fn decode_stored_block(
+    bits: &mut SliceBitReader<'_>,
+    output: &mut Vec<MarkerValue>,
+    window: &mut [MarkerValue],
+    window_pos: &mut usize,
+    total_output: &mut usize,
+) -> Result<()> {
+    bits.align_to_byte();
+    let len = bits.read_u16_le()?;
+    let nlen = bits.read_u16_le()?;
+
+    if len != !nlen {
+        return Err(Error::StoredBlockLengthMismatch { len, nlen });
+    }
+
+    for _ in 0..len {
+        let byte = bits.read_bits(8)? as u8;
+        let mv = MarkerValue::literal(byte);
+        output.push(mv);
+        window[*window_pos] = mv;
+        *window_pos = (*window_pos + 1) % WINDOW_SIZE;
+        *total_output += 1;
+    }
+
+    Ok(())
+}
+
+/// Decode a Huffman-coded DEFLATE block (fixed or dynamic), writing output as MarkerValues.
+#[allow(clippy::too_many_arguments)]
+fn decode_huffman_block(
+    bits: &mut SliceBitReader<'_>,
+    lit_decoder: &HuffmanDecoder,
+    dist_decoder: Option<&HuffmanDecoder>,
+    has_window: bool,
+    initial_window_len: usize,
+    output: &mut Vec<MarkerValue>,
+    window: &mut [MarkerValue],
+    window_pos: &mut usize,
+    total_output: &mut usize,
+) -> Result<()> {
+    loop {
+        let sym = lit_decoder.decode(bits)?;
+
+        if sym <= 255 {
+            // Literal byte
+            let mv = MarkerValue::literal(sym as u8);
+            output.push(mv);
+            window[*window_pos] = mv;
+            *window_pos = (*window_pos + 1) % WINDOW_SIZE;
+            *total_output += 1;
+            continue;
+        }
+
+        if sym == 256 {
+            // End of block
+            break;
+        }
+
+        // Length code (257..=285)
+        if sym > 285 {
+            return Err(Error::InvalidLengthCode(sym));
+        }
+
+        let len_idx = (sym - 257) as usize;
+        let (base_len, extra_bits) = LENGTH_TABLE[len_idx];
+        let extra = if extra_bits > 0 { bits.read_bits(extra_bits)? } else { 0 };
+        let length = base_len + extra as u16;
+
+        // Read distance
+        let dist_dec =
+            dist_decoder.ok_or(Error::Internal("distance code in literal-only block".into()))?;
+        let dist_sym = dist_dec.decode(bits)?;
+        if dist_sym > 29 {
+            return Err(Error::InvalidDistanceCode(dist_sym));
+        }
+
+        let (base_dist, dist_extra_bits) = DISTANCE_TABLE[dist_sym as usize];
+        let dist_extra = if dist_extra_bits > 0 { bits.read_bits(dist_extra_bits)? } else { 0 };
+        let distance = (base_dist + dist_extra as u16) as usize;
+
+        // Resolve the Copy token.
+        resolve_copy(
+            length as usize,
+            distance,
+            has_window,
+            initial_window_len,
+            output,
+            window,
+            window_pos,
+            total_output,
+        );
+    }
+
+    Ok(())
+}
+
+/// Resolve a Copy { length, distance } token into the output buffer.
+///
+/// If `has_window` is true, all references are resolvable (no markers).
+/// Otherwise, references into the unknown preceding window become markers.
+#[allow(clippy::too_many_arguments)]
+#[inline]
+fn resolve_copy(
+    length: usize,
+    distance: usize,
+    has_window: bool,
+    initial_window_len: usize,
+    output: &mut Vec<MarkerValue>,
+    window: &mut [MarkerValue],
+    window_pos: &mut usize,
+    total_output: &mut usize,
+) {
+    for i in 0..length {
+        // Where in the virtual output stream does this byte come from?
+        // total_output + i is the current output position.
+        // The reference points (distance) bytes back from here.
+        let cur_pos = *total_output + i;
+
+        // If has_window, then virtual position 0 corresponds to the start of
+        // the initial window. All decoded output starts at initial_window_len.
+        // The reference position in the virtual stream:
+        //   ref_virtual = (initial_window_len + cur_pos) - distance
+        //
+        // If ref_virtual < 0 (before the window), that's an invalid reference
+        // or one we can't resolve. Without a window, we also need to handle
+        // references into the unknown region.
+
+        let virtual_pos = initial_window_len + cur_pos;
+        if virtual_pos < distance {
+            if has_window {
+                // This would be an out-of-bounds reference even with the window
+                // — shouldn't happen in valid DEFLATE. Emit literal 0 as fallback.
+                let mv = MarkerValue::literal(0);
+                output.push(mv);
+                window[*window_pos] = mv;
+                *window_pos = (*window_pos + 1) % WINDOW_SIZE;
+                continue;
+            } else {
+                // Reference reaches before the start of the chunk into the unknown
+                // preceding 32KB window. Compute the correct offset within that window.
+                let bytes_before_start = distance - virtual_pos;
+                let window_offset =
+                    (WINDOW_SIZE - (bytes_before_start % WINDOW_SIZE)) % WINDOW_SIZE;
+                let mv = MarkerValue::window_ref(window_offset as u16);
+                output.push(mv);
+                window[*window_pos] = mv;
+                *window_pos = (*window_pos + 1) % WINDOW_SIZE;
+                continue;
+            }
+        }
+
+        let ref_virtual = virtual_pos - distance;
+
+        if !has_window && ref_virtual < initial_window_len {
+            // Reference into the unknown preceding window. Compute the offset
+            // within the 32KB window based on the virtual reference position.
+            let bytes_before_start = initial_window_len - ref_virtual;
+            let window_offset = (WINDOW_SIZE - (bytes_before_start % WINDOW_SIZE)) % WINDOW_SIZE;
+            let mv = MarkerValue::window_ref(window_offset as u16);
+            output.push(mv);
+            window[*window_pos] = mv;
+            *window_pos = (*window_pos + 1) % WINDOW_SIZE;
+        } else {
+            // The reference is within the known data — look it up from the
+            // circular window buffer.
+            //
+            // The circular window tracks the last WINDOW_SIZE outputs.
+            // window_pos points to the next write slot and has already been
+            // advanced by prior iterations in this copy. The reference is
+            // always `distance` bytes back from the current write position.
+            let idx = (*window_pos + WINDOW_SIZE - distance) % WINDOW_SIZE;
+            let mv = window[idx];
+            output.push(mv);
+            window[*window_pos] = mv;
+            *window_pos = (*window_pos + 1) % WINDOW_SIZE;
+        }
+    }
+
+    *total_output += length;
+}
+
+/// Extract the final 32KB window from the circular buffer.
+///
+/// Unresolved markers are emitted as placeholder `0` bytes. This window is only
+/// valid for fully-resolved chunks; for chunks with markers, call
+/// [`ChunkData::recompute_final_window`] after [`ChunkData::resolve_markers`].
+fn extract_final_window(window: &[MarkerValue], window_pos: usize, total_output: usize) -> Vec<u8> {
+    // Always produce a full WINDOW_SIZE window, zero-padded at the start.
+    // Marker offsets are 0-based into a 32KB window.
+    let mut result = vec![0u8; WINDOW_SIZE];
+
+    let window_bytes = total_output.min(WINDOW_SIZE);
+    if window_bytes == 0 {
+        return result;
+    }
+
+    // Read from the circular buffer starting at (window_pos - window_bytes) mod WINDOW_SIZE.
+    // Place data at the END of the result (zero-pad at the beginning).
+    let start = (window_pos + WINDOW_SIZE - window_bytes) % WINDOW_SIZE;
+    let pad = WINDOW_SIZE - window_bytes;
+    for i in 0..window_bytes {
+        let idx = (start + i) % WINDOW_SIZE;
+        let mv = window[idx];
+        // If the marker is a literal, extract the byte. If it's a window ref,
+        // we can't resolve it yet — store 0 as placeholder. The final_window
+        // is only meaningful once markers are resolved via recompute_final_window().
+        if mv.is_literal() {
+            result[pad + i] = mv.resolve(&[]);
+        }
+        // else: stays 0 (placeholder for unresolved marker)
+    }
+
+    result
+}
+
+/// Split the output MarkerValues into resolved and marker segments on the ChunkData.
+fn flush_output(chunk: &mut ChunkData, output: &[MarkerValue]) {
+    if output.is_empty() {
+        return;
+    }
+
+    // Check if there are any markers at all — common fast path.
+    let has_markers = output.iter().any(|mv| mv.is_marker());
+
+    if !has_markers {
+        // All literals — convert directly to bytes.
+        let bytes: Vec<u8> = output.iter().map(|mv| mv.resolve(&[])).collect();
+        chunk.append_resolved(bytes);
+        return;
+    }
+
+    // Segment the output into runs of resolved-only and marker-containing spans.
+    // For simplicity, we emit the entire output as a marker buffer when there
+    // are any markers. The ChunkData::resolve_markers path handles this.
+    chunk.append_markers(output.to_vec());
+}
+
+/// Decompress a raw DEFLATE buffer using libdeflate.
+///
+/// This is a fast path for when we have a complete compressed buffer and know
+/// the expected decompressed size (e.g. BGZF blocks or after boundary detection).
+pub fn decode_with_libdeflate(compressed: &[u8], expected_size: usize) -> Result<Vec<u8>> {
+    let mut decompressor = libdeflater::Decompressor::new();
+    let mut output = vec![0u8; expected_size];
+
+    match decompressor.deflate_decompress(compressed, &mut output) {
+        Ok(actual_size) => {
+            if actual_size != expected_size {
+                return Err(Error::SizeMismatch {
+                    expected: expected_size as u32,
+                    found: actual_size as u32,
+                });
+            }
+            Ok(output)
+        }
+        Err(e) => Err(Error::Internal(format!("libdeflate decompression failed: {e}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compress data with gzip and return the full gzip stream.
+    fn gzip_compress(data: &[u8]) -> Vec<u8> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+        let mut e = GzEncoder::new(Vec::new(), Compression::default());
+        e.write_all(data).unwrap();
+        e.finish().unwrap()
+    }
+
+    /// Find the bit offset where DEFLATE data starts in a gzip stream.
+    /// Parses the gzip header and returns the byte offset * 8.
+    fn find_deflate_start(gzip_data: &[u8]) -> usize {
+        use crate::gzip::header::GzipHeader;
+        let mut cursor = std::io::Cursor::new(gzip_data);
+        let _header = GzipHeader::parse(&mut cursor).unwrap();
+        cursor.position() as usize * 8
+    }
+
+    #[test]
+    fn test_speculative_decode_with_empty_window() {
+        // With a known (empty) window at stream start, no markers should be produced.
+        let original = b"Hello, world! This is a test of speculative decompression.";
+        let compressed = gzip_compress(original);
+        let start_bit = find_deflate_start(&compressed);
+        // end_bit: exclude the 8-byte trailer
+        let end_bit = (compressed.len() - 8) * 8;
+        let window: Vec<u8> = vec![];
+
+        let chunk = speculative_decode(&compressed, start_bit, end_bit, Some(&window)).unwrap();
+        assert!(chunk.is_resolved(), "chunk should be fully resolved with known window");
+
+        // Verify the decompressed size matches.
+        assert_eq!(chunk.decompressed_size(), original.len());
+
+        // Verify actual content.
+        let bufs = chunk.resolved_data();
+        let result: Vec<u8> = bufs.iter().flat_map(|b| b.iter().copied()).collect();
+        assert_eq!(result, original.as_slice());
+    }
+
+    #[test]
+    fn test_speculative_decode_with_repetitive_data() {
+        // Repetitive data will produce back-references within the chunk itself.
+        // With a known empty window, these should all resolve.
+        let original: Vec<u8> = b"ABCDEFGH".repeat(100);
+        let compressed = gzip_compress(&original);
+        let start_bit = find_deflate_start(&compressed);
+        let end_bit = (compressed.len() - 8) * 8;
+        let window: Vec<u8> = vec![];
+
+        let chunk = speculative_decode(&compressed, start_bit, end_bit, Some(&window)).unwrap();
+        assert!(chunk.is_resolved());
+        assert_eq!(chunk.decompressed_size(), original.len());
+
+        let bufs = chunk.resolved_data();
+        let result: Vec<u8> = bufs.iter().flat_map(|b| b.iter().copied()).collect();
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn test_speculative_decode_without_window() {
+        // Without a window, back-references into the unknown region produce markers.
+        // We can't easily guarantee markers from a single gzip stream (the first
+        // block starts with an empty window), so we test that the function runs
+        // and produces correct output size.
+        let original: Vec<u8> = b"ABCDEFGH".repeat(1000);
+        let compressed = gzip_compress(&original);
+        let start_bit = find_deflate_start(&compressed);
+        let end_bit = (compressed.len() - 8) * 8;
+
+        // Decode without a window — this simulates a mid-stream chunk.
+        // Since this is actually the start of the stream, no references will
+        // reach before position 0, so it should still be fully resolved.
+        let chunk = speculative_decode(&compressed, start_bit, end_bit, None).unwrap();
+        assert_eq!(chunk.decompressed_size(), original.len());
+    }
+
+    #[test]
+    fn test_speculative_decode_literals_only() {
+        // Data that compresses to mostly literals (random bytes).
+        let original: Vec<u8> = (0..=255).cycle().take(256).collect();
+        let compressed = gzip_compress(&original);
+        let start_bit = find_deflate_start(&compressed);
+        let end_bit = (compressed.len() - 8) * 8;
+        let window: Vec<u8> = vec![];
+
+        let chunk = speculative_decode(&compressed, start_bit, end_bit, Some(&window)).unwrap();
+        assert!(chunk.is_resolved());
+        assert_eq!(chunk.decompressed_size(), original.len());
+
+        let bufs = chunk.resolved_data();
+        let result: Vec<u8> = bufs.iter().flat_map(|b| b.iter().copied()).collect();
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn test_speculative_decode_final_window() {
+        // Verify that the final window is populated.
+        let original: Vec<u8> = vec![0x42; 100];
+        let compressed = gzip_compress(&original);
+        let start_bit = find_deflate_start(&compressed);
+        let end_bit = (compressed.len() - 8) * 8;
+        let window: Vec<u8> = vec![];
+
+        let chunk = speculative_decode(&compressed, start_bit, end_bit, Some(&window)).unwrap();
+        let final_window = chunk.final_window.as_ref().unwrap();
+        // The final window is always 32KB, zero-padded at the front for short chunks.
+        assert_eq!(final_window.len(), WINDOW_SIZE);
+        assert!(final_window[..WINDOW_SIZE - 100].iter().all(|&b| b == 0x00));
+        assert!(final_window[WINDOW_SIZE - 100..].iter().all(|&b| b == 0x42));
+    }
+
+    #[test]
+    fn test_speculative_decode_large_data_window() {
+        // Data larger than 32KB to exercise window wrapping.
+        let original: Vec<u8> = (0..=255u8).cycle().take(50_000).collect();
+        let compressed = gzip_compress(&original);
+        let start_bit = find_deflate_start(&compressed);
+        let end_bit = (compressed.len() - 8) * 8;
+        let window: Vec<u8> = vec![];
+
+        let chunk = speculative_decode(&compressed, start_bit, end_bit, Some(&window)).unwrap();
+        assert!(chunk.is_resolved());
+        assert_eq!(chunk.decompressed_size(), original.len());
+
+        let bufs = chunk.resolved_data();
+        let result: Vec<u8> = bufs.iter().flat_map(|b| b.iter().copied()).collect();
+        assert_eq!(result, original);
+
+        // Final window should be last 32KB.
+        let final_window = chunk.final_window.as_ref().unwrap();
+        assert_eq!(final_window.len(), WINDOW_SIZE);
+        assert_eq!(final_window, &original[original.len() - WINDOW_SIZE..]);
+    }
+
+    #[test]
+    fn test_decode_with_libdeflate() {
+        // Compress with flate2 raw deflate, decompress with libdeflate.
+        let original = b"test data for libdeflate decompression path";
+        let compressed = {
+            use flate2::write::DeflateEncoder;
+            use flate2::Compression;
+            use std::io::Write;
+            let mut e = DeflateEncoder::new(Vec::new(), Compression::default());
+            e.write_all(original).unwrap();
+            e.finish().unwrap()
+        };
+        let result = decode_with_libdeflate(&compressed, original.len()).unwrap();
+        assert_eq!(result, original.as_slice());
+    }
+
+    #[test]
+    fn test_decode_with_libdeflate_size_mismatch() {
+        let original = b"hello";
+        let compressed = {
+            use flate2::write::DeflateEncoder;
+            use flate2::Compression;
+            use std::io::Write;
+            let mut e = DeflateEncoder::new(Vec::new(), Compression::default());
+            e.write_all(original).unwrap();
+            e.finish().unwrap()
+        };
+        // Request wrong size — should get an error.
+        let result = decode_with_libdeflate(&compressed, original.len() + 100);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_speculative_decode_rle_pattern() {
+        // RLE-heavy data: distance < length (overlapping copy).
+        let original: Vec<u8> = vec![b'A'; 10_000];
+        let compressed = gzip_compress(&original);
+        let start_bit = find_deflate_start(&compressed);
+        let end_bit = (compressed.len() - 8) * 8;
+        let window: Vec<u8> = vec![];
+
+        let chunk = speculative_decode(&compressed, start_bit, end_bit, Some(&window)).unwrap();
+        assert!(chunk.is_resolved());
+        assert_eq!(chunk.decompressed_size(), original.len());
+
+        let bufs = chunk.resolved_data();
+        let result: Vec<u8> = bufs.iter().flat_map(|b| b.iter().copied()).collect();
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn test_marker_generation_and_resolution_roundtrip() {
+        // Generate repetitive data large enough to produce multiple DEFLATE blocks.
+        // The pattern repeats a 256-byte sequence many times, guaranteeing back-references.
+        let pattern: Vec<u8> = (0..=255u8).collect();
+        let original: Vec<u8> = pattern.iter().copied().cycle().take(256 * 1000).collect();
+
+        let compressed = gzip_compress(&original);
+        let deflate_start = find_deflate_start(&compressed);
+        let deflate_end = (compressed.len() - 8) * 8;
+
+        // Use the block scanner to find a DEFLATE block boundary after the first block.
+        // Search starting after the first few hundred bits to skip the first block header.
+        use crate::transcoder::block_scanner::scan_for_block;
+        let search_start = deflate_start + 256; // skip well past the first block header
+        let boundary = scan_for_block(&compressed, search_start, deflate_end);
+
+        // If no boundary is found (e.g. the compressor used a single block), skip test.
+        // This is unlikely with 256KB of repetitive data at default compression.
+        let boundary = match boundary {
+            Some(b) => b,
+            None => return, // can't split — nothing to test
+        };
+
+        // The boundary bit_offset includes the BFINAL+BTYPE bits, but scan_for_block
+        // returns the position of the block header. We need to decode everything before
+        // this point to get the correct window.
+
+        // Step 1: Decode the first portion with a known empty window to get correct output.
+        let first_chunk =
+            speculative_decode(&compressed, deflate_start, boundary.bit_offset, Some(&[]))
+                .expect("first chunk decode failed");
+        assert!(first_chunk.is_resolved(), "first chunk should be fully resolved");
+
+        // Collect the first chunk's output.
+        let first_output: Vec<u8> =
+            first_chunk.resolved_data().iter().flat_map(|b| b.iter().copied()).collect();
+
+        // Build the correct window: last 32KB of first_output.
+        let window_start =
+            if first_output.len() > WINDOW_SIZE { first_output.len() - WINDOW_SIZE } else { 0 };
+        let correct_window = &first_output[window_start..];
+
+        // Step 2: Decode the second portion WITH the correct window (ground truth).
+        let truth_chunk =
+            speculative_decode(&compressed, boundary.bit_offset, deflate_end, Some(correct_window))
+                .expect("truth chunk decode failed");
+        assert!(truth_chunk.is_resolved(), "truth chunk should be fully resolved");
+
+        let truth_output: Vec<u8> =
+            truth_chunk.resolved_data().iter().flat_map(|b| b.iter().copied()).collect();
+        assert!(!truth_output.is_empty(), "truth output should not be empty");
+
+        // Step 3: Decode the second portion WITHOUT a window (speculative, produces markers).
+        let mut spec_chunk =
+            speculative_decode(&compressed, boundary.bit_offset, deflate_end, None)
+                .expect("speculative chunk decode failed");
+
+        assert_eq!(
+            spec_chunk.decompressed_size(),
+            truth_output.len(),
+            "speculative and truth chunks should have same size"
+        );
+
+        // Step 4: If there are markers, verify they have correct (non-zero) offsets
+        // for references that don't start at offset 0, then resolve them.
+        if !spec_chunk.is_resolved() {
+            // Resolve markers with the correct window.
+            spec_chunk.resolve_markers(correct_window);
+            assert!(spec_chunk.is_resolved(), "chunk should be resolved after marker resolution");
+
+            // Recompute final_window now that markers are resolved.
+            spec_chunk.recompute_final_window();
+        }
+
+        // Step 5: Verify output matches the ground truth.
+        let spec_output: Vec<u8> =
+            spec_chunk.resolved_data().iter().flat_map(|b| b.iter().copied()).collect();
+        assert_eq!(
+            spec_output, truth_output,
+            "speculative decode + marker resolution must match direct decode"
+        );
+
+        // Step 6: Verify the combined output matches the original.
+        let mut combined = first_output.clone();
+        combined.extend_from_slice(&spec_output);
+        assert_eq!(
+            combined,
+            original[..combined.len()],
+            "combined output must match original data prefix"
+        );
+    }
+
+    #[test]
+    fn test_recompute_final_window_after_resolve() {
+        // Verify that recompute_final_window produces correct bytes after resolution.
+        let original: Vec<u8> = vec![0x42; 100];
+        let compressed = gzip_compress(&original);
+        let start_bit = find_deflate_start(&compressed);
+        let end_bit = (compressed.len() - 8) * 8;
+        let window: Vec<u8> = vec![];
+
+        let mut chunk = speculative_decode(&compressed, start_bit, end_bit, Some(&window)).unwrap();
+        assert!(chunk.is_resolved());
+
+        chunk.recompute_final_window();
+        let final_window = chunk.final_window.as_ref().unwrap();
+        // The final window is always 32KB, zero-padded at the front for short chunks.
+        assert_eq!(final_window.len(), WINDOW_SIZE);
+        assert!(final_window[..WINDOW_SIZE - 100].iter().all(|&b| b == 0x00));
+        assert!(final_window[WINDOW_SIZE - 100..].iter().all(|&b| b == 0x42));
+    }
+}

--- a/src/reader/window_map.rs
+++ b/src/reader/window_map.rs
@@ -1,0 +1,139 @@
+//! Thread-safe storage for sliding windows at chunk boundaries.
+//!
+//! As chunks complete decoding, their final window (last 32KB of output)
+//! is stored here so that the next chunk can use it for marker resolution.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+/// Thread-safe ordered map of 32KB windows keyed by encoded bit offset.
+///
+/// As chunks complete decoding, their final window (last 32KB of output)
+/// is stored here. The next chunk uses this window for marker resolution.
+pub struct WindowMap {
+    inner: Mutex<BTreeMap<usize, Vec<u8>>>,
+}
+
+impl WindowMap {
+    /// Creates a new empty `WindowMap`.
+    pub fn new() -> Self {
+        Self { inner: Mutex::new(BTreeMap::new()) }
+    }
+
+    /// Stores a window at the given encoded bit offset.
+    pub fn insert(&self, encoded_offset: usize, window: Vec<u8>) {
+        self.inner.lock().expect("WindowMap lock poisoned").insert(encoded_offset, window);
+    }
+
+    /// Retrieves a clone of the window at the given encoded bit offset, if present.
+    pub fn get(&self, encoded_offset: usize) -> Option<Vec<u8>> {
+        self.inner.lock().expect("WindowMap lock poisoned").get(&encoded_offset).cloned()
+    }
+
+    /// Removes and returns the window at the given encoded bit offset, if present.
+    pub fn remove(&self, encoded_offset: usize) -> Option<Vec<u8>> {
+        self.inner.lock().expect("WindowMap lock poisoned").remove(&encoded_offset)
+    }
+
+    /// Removes all windows with offsets strictly less than `offset`.
+    ///
+    /// This is used for memory management: once all chunks before a given offset
+    /// have been fully resolved, their windows are no longer needed.
+    pub fn release_before(&self, offset: usize) {
+        let mut map = self.inner.lock().expect("WindowMap lock poisoned");
+        // Split off entries >= offset, keeping only those.
+        *map = map.split_off(&offset);
+    }
+}
+
+impl Default for WindowMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn test_insert_and_get() {
+        let map = WindowMap::new();
+        let window = vec![0xAB; 32_768];
+        map.insert(100, window.clone());
+
+        let retrieved = map.get(100);
+        assert_eq!(retrieved, Some(window));
+    }
+
+    #[test]
+    fn test_get_missing() {
+        let map = WindowMap::new();
+        assert_eq!(map.get(42), None);
+    }
+
+    #[test]
+    fn test_remove() {
+        let map = WindowMap::new();
+        let window = vec![0xCD; 1024];
+        map.insert(200, window.clone());
+
+        let removed = map.remove(200);
+        assert_eq!(removed, Some(window));
+        // After removal, get should return None.
+        assert_eq!(map.get(200), None);
+    }
+
+    #[test]
+    fn test_release_before() {
+        let map = WindowMap::new();
+        map.insert(10, vec![1]);
+        map.insert(20, vec![2]);
+        map.insert(30, vec![3]);
+        map.insert(40, vec![4]);
+
+        map.release_before(25);
+
+        // Offsets 10 and 20 should be gone.
+        assert_eq!(map.get(10), None);
+        assert_eq!(map.get(20), None);
+        // Offsets 30 and 40 should remain.
+        assert_eq!(map.get(30), Some(vec![3]));
+        assert_eq!(map.get(40), Some(vec![4]));
+    }
+
+    #[test]
+    fn test_concurrent_access() {
+        let map = Arc::new(WindowMap::new());
+        let num_threads = 8;
+        let entries_per_thread = 100;
+
+        // Spawn threads that each insert a range of entries.
+        let handles: Vec<_> = (0..num_threads)
+            .map(|t| {
+                let map = Arc::clone(&map);
+                thread::spawn(move || {
+                    for i in 0..entries_per_thread {
+                        let offset = t * entries_per_thread + i;
+                        map.insert(offset, vec![t as u8; 64]);
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+
+        // Verify all entries are present with correct values.
+        for t in 0..num_threads {
+            for i in 0..entries_per_thread {
+                let offset = t * entries_per_thread + i;
+                let window = map.get(offset).expect("missing entry");
+                assert_eq!(window, vec![t as u8; 64]);
+            }
+        }
+    }
+}

--- a/tests/reader.rs
+++ b/tests/reader.rs
@@ -1,0 +1,471 @@
+use rebgzf::reader::ParallelGzipReader;
+use std::io::Read;
+
+fn gzip_compress(data: &[u8]) -> Vec<u8> {
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::Write;
+    let mut e = GzEncoder::new(Vec::new(), Compression::default());
+    e.write_all(data).unwrap();
+    e.finish().unwrap()
+}
+
+fn gzip_compress_level(data: &[u8], level: flate2::Compression) -> Vec<u8> {
+    use flate2::write::GzEncoder;
+    use std::io::Write;
+    let mut e = GzEncoder::new(Vec::new(), level);
+    e.write_all(data).unwrap();
+    e.finish().unwrap()
+}
+
+#[test]
+fn test_small_file() {
+    let original = b"Hello, world! This is a test.";
+    let compressed = gzip_compress(original);
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 2).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+    assert_eq!(output, original);
+}
+
+#[test]
+fn test_large_file_parallel() {
+    // 10 MB repetitive data that compresses well and produces back-references.
+    let original: Vec<u8> = (0..10_000_000).map(|i| (i % 256) as u8).collect();
+    let compressed = gzip_compress(&original);
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 4).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+    assert_eq!(output.len(), original.len());
+    assert_eq!(output, original);
+}
+
+#[test]
+fn test_matches_flate2() {
+    // DNA-like data.
+    let bases = b"ACGTACGTNNNN";
+    let original: Vec<u8> = (0..1_000_000).map(|i| bases[i % bases.len()]).collect();
+    let compressed = gzip_compress(&original);
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    // Parallel reader.
+    let mut par = ParallelGzipReader::from_file(tmp.path(), 4).unwrap();
+    let mut par_out = Vec::new();
+    par.read_to_end(&mut par_out).unwrap();
+
+    // flate2 reference.
+    let mut ref_reader = flate2::read::GzDecoder::new(std::io::BufReader::new(
+        std::fs::File::open(tmp.path()).unwrap(),
+    ));
+    let mut ref_out = Vec::new();
+    ref_reader.read_to_end(&mut ref_out).unwrap();
+
+    assert_eq!(par_out, ref_out);
+}
+
+#[test]
+fn test_streaming_fallback() {
+    let original = b"Streaming fallback test";
+    let compressed = gzip_compress(original);
+    let cursor = std::io::Cursor::new(compressed);
+    let mut reader = ParallelGzipReader::from_reader(cursor, 4).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+    assert_eq!(output, original.to_vec());
+}
+
+#[test]
+fn test_multi_member_gzip_streaming() {
+    let part1 = b"First member data here";
+    let part2 = b"Second member data here";
+    let mut compressed = gzip_compress(part1);
+    compressed.extend_from_slice(&gzip_compress(part2));
+
+    // The streaming path (MultiGzDecoder) handles multi-member gzip correctly.
+    let cursor = std::io::Cursor::new(compressed);
+    let mut reader = ParallelGzipReader::from_reader(cursor, 4).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+
+    let mut expected = part1.to_vec();
+    expected.extend_from_slice(part2);
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn test_multi_member_gzip_from_file() {
+    // The parallel (mmap) path decompresses all gzip members in parallel.
+    let part1 = b"First member data in a file";
+    let part2 = b"Second member data in a file";
+    let mut compressed = gzip_compress(part1);
+    compressed.extend_from_slice(&gzip_compress(part2));
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 2).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+
+    let mut expected = part1.to_vec();
+    expected.extend_from_slice(part2);
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn test_multi_member_gzip_many_members() {
+    // Simulate pigz-style output: many small members concatenated.
+    let members: Vec<Vec<u8>> = (0..50)
+        .map(|i| format!("Member {} with some data to compress\n", i).into_bytes())
+        .collect();
+
+    let mut compressed = Vec::new();
+    let mut expected = Vec::new();
+    for member in &members {
+        compressed.extend_from_slice(&gzip_compress(member));
+        expected.extend_from_slice(member);
+    }
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 4).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn test_multi_member_gzip_large_members() {
+    // Members with enough data to exercise back-references within each member.
+    let member1: Vec<u8> = b"ACGTACGTNNNN".iter().copied().cycle().take(100_000).collect();
+    let member2: Vec<u8> = b"TTTAAAGGGCCC".iter().copied().cycle().take(100_000).collect();
+    let member3: Vec<u8> = (0..=255u8).cycle().take(100_000).collect();
+
+    let mut compressed = gzip_compress(&member1);
+    compressed.extend_from_slice(&gzip_compress(&member2));
+    compressed.extend_from_slice(&gzip_compress(&member3));
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 4).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+
+    let mut expected = member1;
+    expected.extend_from_slice(&member2);
+    expected.extend_from_slice(&member3);
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn test_multi_member_heterogeneous_headers() {
+    // Members compressed at different levels have different XFL bytes in the header.
+    // The structural scanner must handle this (the old exact-match scanner would fail).
+    let part1 = b"compressed with fast level";
+    let part2 = b"compressed with best level";
+    let part3 = b"compressed with default level";
+
+    let mut compressed = gzip_compress_level(part1, flate2::Compression::fast());
+    compressed.extend_from_slice(&gzip_compress_level(part2, flate2::Compression::best()));
+    compressed.extend_from_slice(&gzip_compress_level(part3, flate2::Compression::default()));
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 2).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+
+    let mut expected = part1.to_vec();
+    expected.extend_from_slice(part2);
+    expected.extend_from_slice(part3);
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn test_multi_member_with_trailing_eof_member() {
+    // Some tools (bgzip) append an empty EOF member. The reader should handle this.
+    let part1 = b"data before eof member";
+    let mut compressed = gzip_compress(part1);
+
+    // Append a minimal empty gzip member (empty DEFLATE stream).
+    let empty_member = gzip_compress(b"");
+    compressed.extend_from_slice(&empty_member);
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 2).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+
+    assert_eq!(output, part1.to_vec());
+}
+
+#[test]
+fn test_bgzf_input() {
+    use flate2::Compression;
+    use flate2::GzBuilder;
+    use std::io::Write;
+
+    let original = b"BGZF test data with extra field";
+
+    // BGZF extra field: SI1=B(0x42), SI2=C(0x43), SLEN=2, BSIZE placeholder
+    let mut encoder = GzBuilder::new()
+        .extra(vec![0x42, 0x43, 0x02, 0x00, 0x00, 0x00])
+        .write(Vec::new(), Compression::default());
+    encoder.write_all(original).unwrap();
+    let compressed = encoder.finish().unwrap();
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 2).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+    assert_eq!(output, original);
+}
+
+#[test]
+fn test_gzip_with_filename() {
+    use flate2::Compression;
+    use flate2::GzBuilder;
+    use std::io::Write;
+
+    let original = b"data with filename in gzip header";
+    let mut encoder =
+        GzBuilder::new().filename("test.fastq").write(Vec::new(), Compression::default());
+    encoder.write_all(original).unwrap();
+    let compressed = encoder.finish().unwrap();
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 2).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+    assert_eq!(output, original);
+}
+
+#[test]
+fn test_gzip_with_comment() {
+    use flate2::Compression;
+    use flate2::GzBuilder;
+    use std::io::Write;
+
+    let original = b"data with comment in gzip header";
+    let mut encoder = GzBuilder::new()
+        .comment("This is a test comment")
+        .write(Vec::new(), Compression::default());
+    encoder.write_all(original).unwrap();
+    let compressed = encoder.finish().unwrap();
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 2).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+    assert_eq!(output, original);
+}
+
+#[test]
+fn test_gzip_with_extra_field() {
+    use flate2::Compression;
+    use flate2::GzBuilder;
+    use std::io::Write;
+
+    let original = b"data with non-BGZF extra field";
+    // Random extra data that is NOT a BC subfield
+    let mut encoder = GzBuilder::new()
+        .extra(vec![0x41, 0x41, 0x04, 0x00, 0xDE, 0xAD, 0xBE, 0xEF])
+        .write(Vec::new(), Compression::default());
+    encoder.write_all(original).unwrap();
+    let compressed = encoder.finish().unwrap();
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 2).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+    assert_eq!(output, original);
+}
+
+#[test]
+fn test_empty_gzip() {
+    let original = b"";
+    let compressed = gzip_compress(original);
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 2).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+    assert_eq!(output.len(), 0);
+}
+
+#[test]
+fn test_multi_member_mixed_header_types() {
+    use flate2::Compression;
+    use flate2::GzBuilder;
+    use std::io::Write;
+
+    // Member 1: plain (no flags)
+    let part1 = b"plain member";
+    let compressed1 = gzip_compress(part1);
+
+    // Member 2: with filename
+    let part2 = b"member with filename";
+    let mut encoder2 =
+        GzBuilder::new().filename("reads.fastq").write(Vec::new(), Compression::default());
+    encoder2.write_all(part2).unwrap();
+    let compressed2 = encoder2.finish().unwrap();
+
+    // Member 3: with comment
+    let part3 = b"member with comment";
+    let mut encoder3 =
+        GzBuilder::new().comment("produced by tool X").write(Vec::new(), Compression::default());
+    encoder3.write_all(part3).unwrap();
+    let compressed3 = encoder3.finish().unwrap();
+
+    let mut combined = compressed1;
+    combined.extend_from_slice(&compressed2);
+    combined.extend_from_slice(&compressed3);
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &combined).unwrap();
+
+    let mut reader = ParallelGzipReader::from_file(tmp.path(), 2).unwrap();
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).unwrap();
+
+    let mut expected = part1.to_vec();
+    expected.extend_from_slice(part2);
+    expected.extend_from_slice(part3);
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn test_truncated_gzip() {
+    let original = b"this data will be truncated";
+    let compressed = gzip_compress(original);
+    // Truncate: remove the last 10 bytes (part of DEFLATE data + trailer)
+    let truncated = &compressed[..compressed.len() - 10];
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), truncated).unwrap();
+
+    // Error may occur at construction or during read — either is acceptable.
+    let reader_result = ParallelGzipReader::from_file(tmp.path(), 2);
+    match reader_result {
+        Err(_) => {} // construction failed, that's fine
+        Ok(mut reader) => {
+            let mut output = Vec::new();
+            let result = reader.read_to_end(&mut output);
+            // Either an error, or the output must be a prefix of the original
+            // (partial decompression is acceptable, arbitrary corruption is not).
+            assert!(
+                result.is_err() || original.starts_with(&output),
+                "truncated gzip produced non-prefix output: {} bytes",
+                output.len()
+            );
+        }
+    }
+}
+
+#[test]
+fn test_corrupt_deflate_data() {
+    let original = b"data that will be corrupted in the middle";
+    let mut compressed = gzip_compress(original);
+    // Corrupt some bytes in the DEFLATE data (after the 10-byte header)
+    if compressed.len() > 15 {
+        compressed[12] ^= 0xFF;
+        compressed[13] ^= 0xFF;
+    }
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &compressed).unwrap();
+
+    // Error may occur at construction or during read — either is acceptable.
+    let reader_result = ParallelGzipReader::from_file(tmp.path(), 2);
+    match reader_result {
+        Err(_) => {} // construction failed with error, that's fine
+        Ok(mut reader) => {
+            let mut output = Vec::new();
+            let result = reader.read_to_end(&mut output);
+            assert!(result.is_err());
+        }
+    }
+}
+
+#[test]
+fn test_not_gzip_file() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), b"this is plain text, not gzip").unwrap();
+
+    let result = ParallelGzipReader::from_file(tmp.path(), 2);
+    assert!(result.is_err());
+}
+
+#[test]
+#[ignore] // Only run when test data is available: cargo test -- --ignored test_real_pigz
+fn test_real_pigz_fastq_gz() {
+    // Reads a multi-member gzip FASTQ file (e.g. compressed with pigz) and
+    // compares decompressed output against flate2 as a reference.
+    //
+    // Set TEST_REAL_PIGZ_PATH to override the default path, e.g.:
+    //   TEST_REAL_PIGZ_PATH=/path/to/sample.fastq.gz cargo test -- --ignored test_real_pigz
+    let path = std::env::var("TEST_REAL_PIGZ_PATH").unwrap_or_else(|_| {
+        "/Volumes/scratch-00001/fgumi-pipeline-bench/synthetic-pipeline-xlarge_1.fastq.gz"
+            .to_string()
+    });
+    if !std::path::Path::new(&path).exists() {
+        eprintln!("Skipping test_real_pigz_fastq_gz: file not found at {path}");
+        return;
+    }
+
+    // Compute CRC32 from parallel reader
+    let mut par_reader = ParallelGzipReader::from_file(&path, 8).unwrap();
+    let mut par_hasher = crc32fast::Hasher::new();
+    let mut buf = vec![0u8; 1024 * 1024];
+    let mut par_total = 0u64;
+    loop {
+        let n = par_reader.read(&mut buf).unwrap();
+        if n == 0 {
+            break;
+        }
+        par_hasher.update(&buf[..n]);
+        par_total += n as u64;
+    }
+    let par_crc = par_hasher.finalize();
+
+    // Compute CRC32 from flate2 reference
+    let file = std::fs::File::open(&path).unwrap();
+    let mut ref_reader = flate2::read::MultiGzDecoder::new(std::io::BufReader::new(file));
+    let mut ref_hasher = crc32fast::Hasher::new();
+    let mut ref_total = 0u64;
+    loop {
+        let n = ref_reader.read(&mut buf).unwrap();
+        if n == 0 {
+            break;
+        }
+        ref_hasher.update(&buf[..n]);
+        ref_total += n as u64;
+    }
+    let ref_crc = ref_hasher.finalize();
+
+    assert_eq!(par_total, ref_total, "decompressed size mismatch");
+    assert_eq!(par_crc, ref_crc, "decompressed content CRC32 mismatch");
+}


### PR DESCRIPTION
## Summary

- Adds `ParallelGzipReader` implementing `std::io::Read` for parallel gzip decompression
- Multi-member gzip (pigz output): decompresses members in parallel with libdeflate — **7.3x faster than flate2** at 8 threads on a 3 GB FASTQ.gz
- Single-member gzip: speculative parallel decode using rapidgzip-style marker-based window resolution
- Two constructors: `from_file()` (mmap + parallel) and `from_reader()` (streaming flate2 fallback)
- Replaces flate2 with libdeflate in `--verify` mode
- Streaming memory: batched decompression keeps peak memory low (~64 MB vs 9 GB)
- CRC32 verification on by default
- Comprehensive regression tests for BGZF, multi-member, heterogeneous headers, FNAME/FCOMMENT/FEXTRA flags, empty/corrupt/truncated input

## Benchmark (3 GB FASTQ.gz from pigz, 148K members, 9.3 GB uncompressed)

| Configuration | Time | Throughput | vs flate2 |
|---|---|---|---|
| flate2 baseline | 26.3s | 354 MB/s | 1.0x |
| ParallelGzipReader 1T | 15.5s | 601 MB/s | 1.7x |
| ParallelGzipReader 4T | 5.9s | 1,570 MB/s | 4.4x |
| ParallelGzipReader 8T | 3.6s | 2,572 MB/s | 7.3x |

## Known limitations

- Single-member gzip parallel decode uses a pure Rust DEFLATE parser (~5x slower per-thread than libdeflate/zlib). Multi-member path is the fast one.
- Files > 4 GB uncompressed in single-member mode may fall back to speculative decode due to ISIZE overflow
- See #22 for libdeflater crate improvements that would help

## Test plan

- [ ] `cargo test` — 191 tests including 20 reader integration tests
- [ ] `cargo test --release --test reader -- --ignored` — real 3 GB pigz FASTQ.gz regression (CRC32 match vs flate2)
- [ ] `cargo bench -- parallel_reader` — performance regression check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a parallel gzip reader with configurable threading, streaming fallback, and public reader APIs for file/reader inputs.
  * Adds speculative and libdeflate-backed parallel decoding with marker/window handling and chunked output.

* **Bug Fixes**
  * Verification now continues past per-block decompression failures, recording the first error but processing subsequent blocks.

* **Tests**
  * Extensive unit and integration tests for parallel/multi-member/gzip behaviors.

* **Benchmarks**
  * Added reader benchmarks measuring parallel decompression throughput.

* **Chores**
  * Updated VCS ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->