### PR TITLE
feat: add MappedFile and export gzip member scanning API

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,15 +142,13 @@ Options:
 
 ```rust
 use rebgzf::{
-    CompressionLevel, FormatProfile, ParallelDecodeTranscoder,
+    CompressionLevel, MappedFile, ParallelDecodeTranscoder,
     TranscodeConfig,
 };
 use std::fs::File;
 
 fn main() -> rebgzf::Result<()> {
-    let input = File::open("input.gz")?;
-    // Safety: file must not be modified while mapped
-    let mmap = unsafe { memmap2::Mmap::map(&input)? };
+    let mmap = MappedFile::open("input.gz")?;
     let output = File::create("output.bgz")?;
 
     let config = TranscodeConfig {

--- a/src/bin/rebgzf.rs
+++ b/src/bin/rebgzf.rs
@@ -389,18 +389,13 @@ fn run() -> Result<u8, Box<dyn std::error::Error>> {
 
     let stats = if !is_stdin && !args.progress {
         // Fast path: mmap input for file inputs
-        let file = File::open(&args.input)?;
-        let mmap = unsafe { memmap2::Mmap::map(&file)? };
+        let mmap = rebgzf::MappedFile::open(&args.input)?;
         #[cfg(unix)]
         {
-            let ret = unsafe {
-                libc::madvise(mmap.as_ptr() as *mut libc::c_void, mmap.len(), libc::MADV_SEQUENTIAL)
-            };
-            if ret != 0 && args.verbose {
-                eprintln!(
-                    "Warning: madvise(MADV_SEQUENTIAL) failed: {}",
-                    io::Error::last_os_error()
-                );
+            if let Err(e) = mmap.advise_sequential() {
+                if args.verbose {
+                    eprintln!("Warning: madvise(MADV_SEQUENTIAL) failed: {e}");
+                }
             }
         }
         if config.num_threads == 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod deflate;
 pub mod error;
 pub mod gzip;
 pub mod huffman;
+pub mod mmap;
 pub mod reader;
 pub mod transcoder;
 
@@ -13,7 +14,8 @@ pub use bgzf::{
 };
 pub use deflate::tokens::LZ77Token;
 pub use error::{Error, Result};
-pub use reader::ParallelGzipReader;
+pub use mmap::MappedFile;
+pub use reader::{decode_member_batch, scan_gzip_members, ParallelGzipReader};
 pub use transcoder::{
     parallel::ParallelTranscoder, parallel_decode::ParallelDecodeTranscoder,
     single::SingleThreadedTranscoder,

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -1,0 +1,175 @@
+//! Safe memory-mapped file wrapper.
+//!
+//! Provides [`MappedFile`], a safe abstraction over [`memmap2::Mmap`] that
+//! encapsulates the `unsafe` mmap call so that downstream crates with
+//! `#![deny(unsafe_code)]` can memory-map files without writing any unsafe code
+//! themselves.
+
+use std::fs::File;
+use std::io;
+use std::ops::Deref;
+use std::path::Path;
+
+/// A read-only memory-mapped file.
+///
+/// The mapped region remains valid for the lifetime of this struct.  The
+/// underlying file handle is kept open to satisfy OS-level requirements on some
+/// platforms.
+///
+/// # Safety note
+///
+/// This type wraps [`memmap2::Mmap`] which is inherently `unsafe` because the
+/// OS allows other processes to modify or truncate the backing file while the
+/// mapping is alive.  This wrapper exposes safe constructors as a practical
+/// tradeoff (consistent with common Rust mmap wrappers): the mapped bytes are
+/// treated as an immutable `&[u8]`, but **external modification of the file by
+/// another process can cause undefined behaviour**.  Callers must ensure no
+/// other process writes to or truncates the file while the `MappedFile` is
+/// alive (e.g. via file locks or workflow conventions).
+///
+/// # Example
+///
+/// ```no_run
+/// use rebgzf::MappedFile;
+///
+/// let mapped = MappedFile::open("data.gz")?;
+/// let first_two = &mapped[..2]; // gzip magic bytes
+/// # Ok::<(), std::io::Error>(())
+/// ```
+#[derive(Debug)]
+pub struct MappedFile {
+    mmap: memmap2::Mmap,
+    /// Kept open so the mapping remains valid on all platforms.
+    _file: File,
+}
+
+impl MappedFile {
+    /// Memory-map a file in read-only mode.
+    ///
+    /// Returns an error if the file cannot be opened, is not a regular file, or
+    /// has zero length.
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let file = File::open(path.as_ref())?;
+        Self::from_file(file)
+    }
+
+    /// Memory-map an already-open file.
+    ///
+    /// Returns `Ok(MappedFile)` on success. If the file is not a regular file
+    /// or is empty, returns `Err((io::Error, File))` so the caller can reuse
+    /// the file handle (e.g. for streaming fallback) without re-opening it.
+    /// Other I/O errors (e.g. mmap failure) are returned with the file handle
+    /// as well.
+    pub fn try_from_file(file: File) -> std::result::Result<Self, (io::Error, File)> {
+        let metadata = match file.metadata() {
+            Ok(m) => m,
+            Err(e) => return Err((e, file)),
+        };
+
+        if !metadata.is_file() {
+            return Err((
+                io::Error::new(io::ErrorKind::InvalidInput, "MappedFile requires a regular file"),
+                file,
+            ));
+        }
+        if metadata.len() == 0 {
+            return Err((
+                io::Error::new(io::ErrorKind::InvalidInput, "MappedFile requires a non-empty file"),
+                file,
+            ));
+        }
+
+        // Safety: we keep the file open for the lifetime of the mapping and
+        // never write through it.  External modification of the backing file
+        // is the caller's responsibility to prevent (see struct-level docs).
+        let mmap = match unsafe { memmap2::Mmap::map(&file) } {
+            Ok(m) => m,
+            Err(e) => return Err((e, file)),
+        };
+
+        Ok(Self { mmap, _file: file })
+    }
+
+    /// Memory-map an already-open file, consuming it on success.
+    ///
+    /// Returns an error if the file is not a regular file or has zero length.
+    /// Use [`try_from_file`](Self::try_from_file) when you need the file handle
+    /// back on failure.
+    pub fn from_file(file: File) -> io::Result<Self> {
+        Self::try_from_file(file).map_err(|(e, _)| e)
+    }
+
+    /// Advise the OS that the mapped region will be accessed sequentially.
+    ///
+    /// This is a best-effort hint; failure is non-fatal.  Only available on
+    /// Unix platforms.
+    #[cfg(unix)]
+    pub fn advise_sequential(&self) -> io::Result<()> {
+        self.mmap.advise(memmap2::Advice::Sequential)
+    }
+
+    /// Returns the length of the mapped region in bytes.
+    pub fn len(&self) -> usize {
+        self.mmap.len()
+    }
+
+    /// Returns `true` if the mapped region is empty.
+    ///
+    /// This always returns `false` because [`open`](Self::open) rejects
+    /// zero-length files.
+    pub fn is_empty(&self) -> bool {
+        self.mmap.is_empty()
+    }
+}
+
+impl Deref for MappedFile {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.mmap
+    }
+}
+
+impl AsRef<[u8]> for MappedFile {
+    fn as_ref(&self) -> &[u8] {
+        &self.mmap
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_open_and_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bin");
+        {
+            let mut f = File::create(&path).unwrap();
+            f.write_all(b"hello").unwrap();
+        }
+
+        let mapped = MappedFile::open(&path).unwrap();
+        assert_eq!(mapped.len(), 5);
+        assert!(!mapped.is_empty());
+        assert_eq!(&*mapped, b"hello");
+        assert_eq!(mapped.as_ref(), b"hello");
+    }
+
+    #[test]
+    fn test_open_empty_file_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.bin");
+        File::create(&path).unwrap();
+
+        let err = MappedFile::open(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn test_open_nonexistent_fails() {
+        let err = MappedFile::open("/nonexistent/path").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+}

--- a/src/reader/fetcher.rs
+++ b/src/reader/fetcher.rs
@@ -176,21 +176,40 @@ impl ChunkFetcher {
     /// lazy batch decoding instead of pre-decoding everything here.
     pub fn from_data(data: &[u8], config: FetcherConfig) -> Result<Self> {
         let members = scan_gzip_members(data);
-
-        // Single member: parse header and delegate to the existing path.
-        if members.is_empty() {
-            return Err(Error::Internal("no gzip members found".into()));
+        match members.as_slice() {
+            [] => Err(Error::Internal("no gzip members found".into())),
+            [member] => Self::from_member(data, *member, config),
+            _ => Err(Error::Internal(
+                "multiple gzip members detected; use decode_member_batch for concatenated streams"
+                    .into(),
+            )),
         }
+    }
 
-        let (start, end) = members[0];
+    /// Create a fetcher for a single gzip member with known byte boundaries.
+    ///
+    /// Use this when member boundaries have already been scanned (e.g. via
+    /// [`scan_gzip_members`]) to avoid a redundant scan.
+    pub fn from_member(data: &[u8], member: (usize, usize), config: FetcherConfig) -> Result<Self> {
+        let (start, end) = member;
+        if start >= end || end > data.len() {
+            return Err(Error::Internal(format!(
+                "invalid member range ({start}, {end}) for input of {} bytes",
+                data.len()
+            )));
+        }
         let member_data = &data[start..end];
         let mut cursor = std::io::Cursor::new(member_data);
         let _header = GzipHeader::parse(&mut cursor)
             .map_err(|e| Error::Internal(format!("gzip header: {e}")))?;
-        let header_size = start + cursor.position() as usize;
+        let header_len = cursor.position() as usize;
+        if member_data.len() < header_len + 8 {
+            return Err(Error::Internal(format!("member range ({start}, {end}) is truncated")));
+        }
+        let header_size = start + header_len;
 
         // Trailer is last 8 bytes of the member.
-        let deflate_end = end.saturating_sub(8);
+        let deflate_end = end - 8;
 
         Self::new(data, header_size, deflate_end, config)
     }
@@ -231,13 +250,26 @@ fn is_gzip_header(data: &[u8], pos: usize) -> bool {
     GzipHeader::parse(&mut cursor).is_ok()
 }
 
-/// Scan file data for gzip member boundaries.
+/// Scan file data for gzip member boundaries (heuristic).
 ///
 /// Returns a list of `(member_start, member_end)` byte offset pairs.
 /// Each member spans from its gzip header to the byte before the next member
 /// (or EOF).
 ///
-/// Strategy: first try exact-match scanning using the first member's complete
+/// # Heuristic behaviour
+///
+/// This scanner uses two strategies to locate member boundaries and may produce
+/// **false positives** (byte sequences that look like gzip headers but are not)
+/// or **false negatives** (members with empty payloads or `ISIZE > 1 MiB`).
+/// For uniform-header files produced by `pigz` or `bgzip` the scan is exact.
+///
+/// When consuming the returned boundaries, use [`decode_member_batch`] which
+/// contains a merge-retry path that handles false-positive boundaries
+/// gracefully, or validate each boundary independently before use.
+///
+/// # Strategy
+///
+/// First try exact-match scanning using the first member's complete
 /// header bytes as a signature (fast, no false positives for pigz/bgzip where
 /// all members share identical headers). If the first exact-match scan finds
 /// only one member but the file is large, fall back to structural validation

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -13,11 +13,13 @@ mod speculative;
 mod window_map;
 
 pub use chunk::ChunkData;
-pub use fetcher::{ChunkFetcher, FetcherConfig};
+pub use fetcher::{decode_member_batch, scan_gzip_members, ChunkFetcher, FetcherConfig};
 pub use marker::{apply_window, contains_markers, MarkerValue};
 pub use replacer::replace_markers;
 pub use speculative::{decode_with_libdeflate, speculative_decode};
 pub use window_map::WindowMap;
+
+use crate::mmap::MappedFile;
 
 use std::collections::VecDeque;
 use std::fs::File;
@@ -43,7 +45,7 @@ enum ReaderInner {
     /// Multi-member gzip: decompress batches of members on demand.
     MultiMember {
         /// Memory-mapped file data (kept alive for the reader's lifetime).
-        mmap: memmap2::Mmap,
+        mapped: MappedFile,
         /// Byte-offset boundaries for each member: `(start, end)`.
         members: Vec<(usize, usize)>,
         /// Index of the next member to start decoding in the next batch.
@@ -59,8 +61,8 @@ enum ReaderInner {
     },
     /// Single-member gzip: all chunks pre-decoded via speculative parallel decode.
     SingleMember {
-        /// Memory map kept alive for safety.
-        _mmap: memmap2::Mmap,
+        /// Mapped file kept alive for safety.
+        _mapped: MappedFile,
         /// Pre-decoded chunk fetcher.
         fetcher: fetcher::ChunkFetcher,
     },
@@ -81,47 +83,49 @@ impl ParallelGzipReader {
     /// * `threads` - number of worker threads (0 = auto-detect)
     pub fn from_file<P: AsRef<Path>>(path: P, threads: usize) -> io::Result<Self> {
         let file = File::open(path.as_ref())?;
-        let metadata = file.metadata()?;
-
-        if metadata.is_file() && metadata.len() > 0 {
-            // Safety: the file is a regular file that we keep open for the lifetime
-            // of the mmap. We do not write to the mmap.
-            let mmap = unsafe { memmap2::Mmap::map(&file)? };
-
-            let threads = if threads == 0 { num_cpus::get() } else { threads };
-            let config = FetcherConfig { threads, chunk_size: 4 * 1024 * 1024, verify_crc: true };
-
-            let members = fetcher::scan_gzip_members(mmap.as_ref());
-
-            if members.len() > 1 {
-                // Multi-member: set up lazy batch decoding.
-                let batch_size = threads * 64;
-                Ok(Self {
-                    inner: ReaderInner::MultiMember {
-                        mmap,
-                        members,
-                        next_batch_start: 0,
-                        batch_size,
-                        num_threads: threads,
-                        verify_crc: config.verify_crc,
-                        pending_chunks: VecDeque::new(),
-                    },
-                    buffer: Vec::new(),
-                    buffer_pos: 0,
-                })
-            } else {
-                // Single member: pre-decode everything via speculative decode.
-                let fetcher = fetcher::ChunkFetcher::from_data(mmap.as_ref(), config)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-
-                Ok(Self {
-                    inner: ReaderInner::SingleMember { _mmap: mmap, fetcher },
-                    buffer: Vec::new(),
-                    buffer_pos: 0,
-                })
+        let mapped = match MappedFile::try_from_file(file) {
+            Ok(m) => m,
+            Err((_e, file)) => {
+                // Mmap failed (non-regular file, empty, unsupported FS, address
+                // space exhaustion, etc.) — fall back to streaming decode.
+                return Self::from_reader(file, threads);
             }
+        };
+
+        let threads = if threads == 0 { num_cpus::get() } else { threads };
+        let config = FetcherConfig { threads, chunk_size: 4 * 1024 * 1024, verify_crc: true };
+
+        let members = fetcher::scan_gzip_members(&mapped);
+
+        if members.len() > 1 {
+            // Multi-member: set up lazy batch decoding.
+            let batch_size = threads.saturating_mul(64).max(1);
+            Ok(Self {
+                inner: ReaderInner::MultiMember {
+                    mapped,
+                    members,
+                    next_batch_start: 0,
+                    batch_size,
+                    num_threads: threads,
+                    verify_crc: config.verify_crc,
+                    pending_chunks: VecDeque::new(),
+                },
+                buffer: Vec::new(),
+                buffer_pos: 0,
+            })
         } else {
-            Self::from_reader(file, threads)
+            // Single member: use pre-scanned boundaries to avoid redundant scan.
+            let member = members.into_iter().next().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "no gzip members found")
+            })?;
+            let fetcher = fetcher::ChunkFetcher::from_member(&mapped, member, config)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+            Ok(Self {
+                inner: ReaderInner::SingleMember { _mapped: mapped, fetcher },
+                buffer: Vec::new(),
+                buffer_pos: 0,
+            })
         }
     }
 
@@ -153,7 +157,7 @@ impl Read for ParallelGzipReader {
 
         match &mut self.inner {
             ReaderInner::MultiMember {
-                mmap,
+                mapped,
                 members,
                 next_batch_start,
                 batch_size,
@@ -183,11 +187,11 @@ impl Read for ParallelGzipReader {
                         return Ok(0); // EOF
                     }
 
-                    let batch_end = (*next_batch_start + *batch_size).min(members.len());
+                    let batch_end = next_batch_start.saturating_add(*batch_size).min(members.len());
                     let batch_members = &members[*next_batch_start..batch_end];
 
                     let new_chunks = fetcher::decode_member_batch(
-                        mmap.as_ref(),
+                        mapped.as_ref(),
                         batch_members,
                         *num_threads,
                         *verify_crc,


### PR DESCRIPTION
## Summary

- Add `MappedFile`, a safe wrapper over `memmap2::Mmap` that encapsulates all `unsafe` mmap calls, enabling downstream crates with `#![deny(unsafe_code)]` (e.g. fgumi) to memory-map files
- Export `scan_gzip_members` and `decode_member_batch` from the crate root for downstream gzip member boundary scanning and parallel decompression
- Add `ChunkFetcher::from_member` for use with pre-scanned member boundaries, avoiding redundant scans
- Migrate the CLI binary to use `MappedFile`, centralizing all mmap usage in the crate

## Motivation

fgumi's `StreamReader::Gzip` variant needs to mmap files and scan gzip member boundaries to feed raw compressed members through its pipeline. This was blocked by:
1. `scan_gzip_members` not being publicly exported
2. mmap requiring `unsafe`, conflicting with fgumi's `#![deny(unsafe_code)]`

## New public API

```rust
// Safe mmap wrapper
let mapped = rebgzf::MappedFile::open("data.gz")?;

// Scan for member boundaries
let members = rebgzf::scan_gzip_members(&mapped);

// Access raw member bytes
for (start, end) in &members {
    let member_data = &mapped[*start..*end];
}

// Or decode members in parallel
let chunks = rebgzf::decode_member_batch(&mapped, &members, num_threads, true)?;
```

## Test plan

- [ ] All 145 unit tests pass
- [ ] All 63 integration tests pass (44 run, 2 ignored CLI tests)
- [ ] All 20 reader tests pass (19 run, 1 ignored)
- [ ] Doc-test compiles
- [ ] Clippy clean with `-D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a safer memory-mapped file abstraction and replaced direct mappings to improve robustness and error handling.
  * Better fallback behavior for non-regular or empty inputs and improved optional verbose warnings on mapping issues.

* **New Features**
  * Reader API now exposes additional decoding and member-scanning capabilities.
  * Added a member-based fetcher path to simplify single-member decoding flows.

* **Documentation**
  * Updated usage example to use the new memory-mapped helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->